### PR TITLE
biggerskin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 set(icub_firmware_shared_MAJOR_VERSION 0)
 set(icub_firmware_shared_MINOR_VERSION 1)
-set(icub_firmware_shared_PATCH_VERSION 2)
+set(icub_firmware_shared_PATCH_VERSION 3)
 set(icub_firmware_shared_VERSION ${icub_firmware_shared_MAJOR_VERSION}.${icub_firmware_shared_MINOR_VERSION}.${icub_firmware_shared_PATCH_VERSION})
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoSkin.h
+++ b/eth/embobj/plus/comm-v2/icub/EoSkin.h
@@ -97,13 +97,13 @@ typedef struct
     uint8_t         data[8];    // the can payload  
 } eOsk_candata_t;   EO_VERIFYsizeof(eOsk_candata_t, 10);
 
-enum {eosk_capacity_arrayof_skincandata = 9 };
+enum {eosk_capacity_arrayof_skincandata = 24 };
 
-typedef struct              // size is 4+12*10 = 124  4+9*10 = 94
+typedef struct              // size is 4+24*10 = 244
 {
     eOarray_head_t          head;
     uint8_t                 data[eosk_capacity_arrayof_skincandata*sizeof(eOsk_candata_t)];      
-} EOarray_of_skincandata_t; //EO_VERIFYsizeof(EOarray_of_skincandata_t, 124);
+} EOarray_of_skincandata_t; EO_VERIFYsizeof(EOarray_of_skincandata_t, 244);
 
 //typedef struct              // size is 4+10*16+0 = 164
 //{
@@ -208,16 +208,16 @@ typedef struct
 typedef struct                  // size is: 124+4+0 = 128  or 94+2 = 96                  
 {
     EOarray_of_skincandata_t    arrayofcandata;
-    uint8_t                     filler04[2];                           
-} eOsk_status_t;                //EO_VERIFYsizeof(eOsk_status_t, 96);
+    uint8_t                     filler04[4];                           
+} eOsk_status_t;                EO_VERIFYsizeof(eOsk_status_t, 248);
 
 
-typedef struct                  // size is: 8+128+16 = 152 or 8+96+16=120
+typedef struct                  // size is: 8+248+16 = 272 
 {
     eOsk_config_t               config; 
     eOsk_status_t               status;
     eOsk_command_t              cmmnds;    
-} eOsk_skin_t;                  //EO_VERIFYsizeof(eOsk_skin_t, 152);
+} eOsk_skin_t;                  EO_VERIFYsizeof(eOsk_skin_t, 272);
 
 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolSK.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolSK.h
@@ -55,7 +55,7 @@ extern "C" {
 
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
-enum { eoprot_version_sk_major = 1, eoprot_version_sk_minor = 1 };
+enum { eoprot_version_sk_major = 2, eoprot_version_sk_minor = 0 };
 
 enum { eoprot_entities_sk_numberof = eosk_entities_numberof };
 


### PR DESCRIPTION
increased eosk_capacity_arrayof_skincandata to 24, so that we can send regular ropframes less often