### PR TITLE
Change compatibility option of the generated cmake version file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endforeach()
 # icub_firmware_shared-config-version.cmake (build tree and installed) (use AnyNewerVersion or ExactVersion or SameMajorVersion)
 write_basic_package_version_file(${CMAKE_BINARY_DIR}/icub_firmware_shared-config-version.cmake
                                  VERSION ${icub_firmware_shared_VERSION}
-                                 COMPATIBILITY ExactVersion)
+                                 COMPATIBILITY SameMajorVersion)
 
 #install(FILES ${CMAKE_BINARY_DIR}/icub_firmware_shared-config-version.cmake
 #        DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION})


### PR DESCRIPTION
I talked with @randaz81 and I told me that he is ok with having a `SameMajorVersion` policy. 
To see the definition of this version policy, check https://cmake.org/cmake/help/v3.0/module/CMakePackageConfigHelpers.html . 
That means that any newer version is ok, as long as it has the same major number of the request version.

cc @drdanz @marcoaccame @valegagge @ale-git