### PR TITLE
Allow using from source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(icub_firmware_shared_VERSION ${icub_firmware_shared_MAJOR_VERSION}.${icub_fi
 
 
 include(CMakePackageConfigHelpers)
-#include(GNUInstallDirs)
+include(GNUInstallDirs)
 include(FeatureSummary)
 
 
@@ -50,8 +50,8 @@ write_basic_package_version_file(${CMAKE_BINARY_DIR}/icub_firmware_shared-config
                                  VERSION ${icub_firmware_shared_VERSION}
                                  COMPATIBILITY ExactVersion)
 
-#install(FILES ${CMAKE_BINARY_DIR}/icub_firmware_shared-config-version.cmake
-#        DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION})
+install(FILES ${CMAKE_BINARY_DIR}/icub_firmware_shared-config-version.cmake
+        DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION})
 
 
 # icub_firmware_shared-config.cmake (build tree)
@@ -65,18 +65,18 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/icub_firmware_shared-c
                               PATH_VARS ${path_vars})
 
 # icub_firmware_shared-config.cmake (installed)
-#foreach(target ${targets})
-#    get_property(icub_firmware_shared_${target}_INCLUDE_DIR GLOBAL PROPERTY icub_firmware_shared_${target}_INSTALL_INCLUDE_DIR)
-#    get_filename_component(icub_firmware_shared_${target}_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${icub_firmware_shared_${target}_INCLUDE_DIR}" ABSOLUTE)
-#endforeach()
-#configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/icub_firmware_shared-config.cmake.in
-#                              ${CMAKE_BINARY_DIR}/icub_firmware_shared-config.cmake.install
-#                              INSTALL_DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION}
-#                              PATH_VARS ${path_vars})
-#
-#install(FILES ${CMAKE_BINARY_DIR}/icub_firmware_shared-config.cmake.install
-#        DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION}
-#        RENAME icub_firmware_shared-config.cmake)
+foreach(target ${targets})
+    get_property(icub_firmware_shared_${target}_INCLUDE_DIR GLOBAL PROPERTY icub_firmware_shared_${target}_INSTALL_INCLUDE_DIR)
+    get_filename_component(icub_firmware_shared_${target}_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${icub_firmware_shared_${target}_INCLUDE_DIR}" ABSOLUTE)
+endforeach()
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/icub_firmware_shared-config.cmake.in
+                              ${CMAKE_BINARY_DIR}/icub_firmware_shared-config.cmake.install
+                              INSTALL_DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION}
+                              PATH_VARS ${path_vars})
+
+install(FILES ${CMAKE_BINARY_DIR}/icub_firmware_shared-config.cmake.install
+        DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION}
+        RENAME icub_firmware_shared-config.cmake)
 
 
 # # icub_firmware_shared-targets.cmake (build tree)
@@ -91,7 +91,7 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/icub_firmware_shared-c
 #         DESTINATION ${icub_firmware_shared_CMAKE_DESTINATION}
 #         FILE icub_firmware_shared-targets.cmake)
 
-#include(AddUninstallTarget)
+include(AddUninstallTarget)
 
 set_property (CACHE CMAKE_INSTALL_PREFIX PROPERTY TYPE INTERNAL)
 set_property (CACHE WITH_CANPROTOCOLLIB  PROPERTY TYPE INTERNAL)

--- a/can/CMakeLists.txt
+++ b/can/CMakeLists.txt
@@ -5,8 +5,8 @@
 
 project(canProtocolLib NONE)
 if(WITH_CANPROTOCOLLIB)
-    #install(DIRECTORY canProtocolLib
-    #        DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
+    install(DIRECTORY canProtocolLib
+            DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
 endif()
 set_property(GLOBAL APPEND PROPERTY icub_firmware_shared_TARGETS canProtocolLib)
 set_property(GLOBAL PROPERTY icub_firmware_shared_canProtocolLib_BUILD_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -5,10 +5,10 @@
 
 project(embobj NONE)
 if(WITH_EMBOBJ)
-    #install(DIRECTORY embobj
-    #        DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
-    #install(DIRECTORY robotconfig
-    #        DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
+    install(DIRECTORY embobj
+            DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
+    install(DIRECTORY robotconfig
+            DESTINATION ${icub_firmware_shared_INCLUDE_DIR})
 endif()
 
 set_property(GLOBAL APPEND PROPERTY icub_firmware_shared_TARGETS embobj)

--- a/icub_firmware_shared-config-version.cmake
+++ b/icub_firmware_shared-config-version.cmake
@@ -1,0 +1,60 @@
+# This is a basic version file for the Config-mode of find_package(), modified
+# to find icub_firmware_shared from the source directory.
+#
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is equal to the requested version.
+# The tweak version component is ignored.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+
+file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" _contents REGEX "icub_firmware_shared_[A-Z]+_VERSION")
+if(_contents)
+  string(REGEX REPLACE ".*icub_firmware_shared_MAJOR_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_MAJOR_VERSION "${_contents}")
+  string(REGEX REPLACE ".*icub_firmware_shared_MINOR_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_MINOR_VERSION "${_contents}")
+  string(REGEX REPLACE ".*icub_firmware_shared_PATCH_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_PATCH_VERSION "${_contents}")
+  set(icub_firmware_shared_VERSION ${icub_firmware_shared_MAJOR_VERSION}.${icub_firmware_shared_MINOR_VERSION}.${icub_firmware_shared_PATCH_VERSION})
+else()
+  set(icub_firmware_shared_VERSION icub_firmware_shared_NOTFOUND)
+endif()
+
+
+set(PACKAGE_VERSION "${icub_firmware_shared_VERSION}")
+
+if("${icub_firmware_shared_VERSION}" MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)\\.") # strip the tweak version
+  set(CVF_VERSION_NO_TWEAK "${CMAKE_MATCH_1}")
+else()
+  set(CVF_VERSION_NO_TWEAK "${icub_firmware_shared_VERSION}")
+endif()
+
+if(PACKAGE_FIND_VERSION MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)\\.") # strip the tweak version
+  set(REQUESTED_VERSION_NO_TWEAK "${CMAKE_MATCH_1}")
+else()
+  set(REQUESTED_VERSION_NO_TWEAK "${PACKAGE_FIND_VERSION}")
+endif()
+
+if(REQUESTED_VERSION_NO_TWEAK STREQUAL CVF_VERSION_NO_TWEAK)
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+endif()
+
+if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+  set(PACKAGE_VERSION_EXACT TRUE)
+endif()
+
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "" STREQUAL "")
+   return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "")
+  math(EXPR installedBits " * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()

--- a/icub_firmware_shared-config.cmake
+++ b/icub_firmware_shared-config.cmake
@@ -1,0 +1,55 @@
+# Copyright: (C) 2014, 2017 iCub Facility, Istituto Italiano di Tecnologia
+# Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" _contents REGEX "icub_firmware_shared_[A-Z]+_VERSION")
+if(_contents)
+  string(REGEX REPLACE ".*icub_firmware_shared_MAJOR_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_MAJOR_VERSION "${_contents}")
+  string(REGEX REPLACE ".*icub_firmware_shared_MINOR_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_MINOR_VERSION "${_contents}")
+  string(REGEX REPLACE ".*icub_firmware_shared_PATCH_VERSION[ \t]+([0-9]+).*" "\\1" icub_firmware_shared_PATCH_VERSION "${_contents}")
+  set(icub_firmware_shared_VERSION ${icub_firmware_shared_MAJOR_VERSION}.${icub_firmware_shared_MINOR_VERSION}.${icub_firmware_shared_PATCH_VERSION})
+else()
+  set(icub_firmware_shared_VERSION icub_firmware_shared_NOTFOUND)
+endif()
+
+
+
+####### Expanded from @PACKAGE_INIT@ by configure_package_config_file() #######
+####### Any changes to this file will be overwritten by the next CMake run ####
+####### The input file was icub_firmware_shared-config.cmake.in        ########
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+
+macro(set_and_check _var _file)
+  set(${_var} "${_file}")
+  if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
+  endif()
+endmacro()
+
+macro(check_required_components _NAME)
+  foreach(comp ${${_NAME}_FIND_COMPONENTS})
+    if(NOT ${_NAME}_${comp}_FOUND)
+      if(${_NAME}_FIND_REQUIRED_${comp})
+        set(${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+####################################################################################
+
+set_and_check(icub_firmware_shared_canProtocolLib_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/can")
+set_and_check(icub_firmware_shared_embobj_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/eth")
+
+set(_components canProtocolLib
+                embobj)
+
+# if(NOT TARGET YARP_fw::embObj)
+#     include(${CMAKE_CURRENT_LIST_DIR}/icub_firmware_shared-targets.cmake)
+# endif()
+
+set(icub_firmware_shared_canProtocolLib_FOUND ON)
+set(icub_firmware_shared_embobj_FOUND ON)
+
+check_required_components(icub_firmware_shared)


### PR DESCRIPTION
This allows to set `icub_firmware_shared_DIR` to the source directory and therefore runing cmake and make is no longer required (unless you want the visual studio projects or similar).

I basically modified the generated files to add a regular expression to read the version from the `CMakeLists.txt` file.

Also restore installation that was removed in 0da92ea6ea3c922e82b51e7aa29acf514235ca15.

cc @traversaro 