### PR TITLE
Flexible motor input on 2FOC boards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 set(icub_firmware_shared_MAJOR_VERSION 4)
 set(icub_firmware_shared_MINOR_VERSION 0)
-set(icub_firmware_shared_PATCH_VERSION 5)
+set(icub_firmware_shared_PATCH_VERSION 6)
 set(icub_firmware_shared_VERSION ${icub_firmware_shared_MAJOR_VERSION}.${icub_firmware_shared_MINOR_VERSION}.${icub_firmware_shared_PATCH_VERSION})
 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
@@ -72,7 +72,9 @@ typedef enum
     eoprot_tag_mc_joint_wholeitem                                   =  0,
     eoprot_tag_mc_joint_config                                      =  1,
     eoprot_tag_mc_joint_config_pidposition                          =  2,
+    eoprot_tag_mc_joint_config_pidtrajectory                        =  2,
     eoprot_tag_mc_joint_config_pidvelocity                          =  3,
+    eoprot_tag_mc_joint_config_piddirect                            =  3,
     eoprot_tag_mc_joint_config_pidtorque                            =  4,
     eoprot_tag_mc_joint_config_userlimits                           =  5,
     eoprot_tag_mc_joint_config_impedance                            =  6,
@@ -106,8 +108,8 @@ typedef enum
 {
     eoprot_rwm_mc_joint_wholeitem                                   = eo_nv_rwmode_RO,
     eoprot_rwm_mc_joint_config                                      = eo_nv_rwmode_RW,
-    eoprot_rwm_mc_joint_config_pidposition                          = eo_nv_rwmode_RW,
-    eoprot_rwm_mc_joint_config_pidvelocity                          = eo_nv_rwmode_RW,
+    eoprot_rwm_mc_joint_config_pidtrajectory                        = eo_nv_rwmode_RW,
+    eoprot_rwm_mc_joint_config_piddirect                            = eo_nv_rwmode_RW,
     eoprot_rwm_mc_joint_config_pidtorque                            = eo_nv_rwmode_RW,
     eoprot_rwm_mc_joint_config_userlimits                           = eo_nv_rwmode_RW,
     eoprot_rwm_mc_joint_config_impedance                            = eo_nv_rwmode_RW,
@@ -148,11 +150,13 @@ typedef enum
     eoprot_tag_mc_motor_config_rotorencoder                         = 4,
     eoprot_tag_mc_motor_config_pwmlimit                             = 5,
     eoprot_tag_mc_motor_config_temperaturelimit                     = 6,
-    eoprot_tag_mc_motor_status                                      = 7,
-    eoprot_tag_mc_motor_status_basic                                = 8
+    eoprot_tag_mc_motor_config_pidcurrent                           = 7,
+    eoprot_tag_mc_motor_config_pidspeed                             = 8,
+    eoprot_tag_mc_motor_status                                      = 9,
+    eoprot_tag_mc_motor_status_basic                                = 10
 } eOprot_tag_mc_motor_t;
 
-enum { eoprot_tags_mc_motor_numberof = 9 };   // it MUST be equal to the number of tags 
+enum { eoprot_tags_mc_motor_numberof = 11 };   // it MUST be equal to the number of tags 
 
 
 /** @typedef    typedef enum eOprot_rwm_mc_motor_t
@@ -169,11 +173,13 @@ typedef enum
     eoprot_rwm_mc_motor_config_rotorencoder                         = eo_nv_rwmode_RW,
     eoprot_rwm_mc_motor_config_pwmlimit                             = eo_nv_rwmode_RW,
     eoprot_rwm_mc_motor_config_temperaturelimit                     = eo_nv_rwmode_RW,
+    eoprot_rwm_mc_motor_config_pidcurrent                           = eo_nv_rwmode_RW,
+    eoprot_rwm_mc_motor_config_pidspeed                             = eo_nv_rwmode_RW,
     eoprot_rwm_mc_motor_status                                      = eo_nv_rwmode_RO,
     eoprot_rwm_mc_motor_status_basic                                = eo_nv_rwmode_RO
 } eOprot_rwm_mc_motor_t;  
 
-enum { eoprot_rwms_mc_motor_numberof = 9 };   // it MUST be equal to the number of rw modes
+enum { eoprot_rwms_mc_motor_numberof = 11 };   // it MUST be equal to the number of rw modes
 
 
 
@@ -321,6 +327,12 @@ extern void eoprot_fun_UPDT_mc_motor_wholeitem(const EOnv* nv, const eOropdescri
 
 extern void eoprot_fun_INIT_mc_motor_config(const EOnv* nv);
 extern void eoprot_fun_UPDT_mc_motor_config(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_mc_motor_config_pidcurrent(const EOnv* nv);
+extern void eoprot_fun_UPDT_mc_motor_config_pidcurrent(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_mc_motor_config_pidspeed(const EOnv* nv);
+extern void eoprot_fun_UPDT_mc_motor_config_pidspeed(const EOnv* nv, const eOropdescriptor_t* rd);
 
 extern void eoprot_fun_INIT_mc_motor_config_currentlimits(const EOnv* nv);
 extern void eoprot_fun_UPDT_mc_motor_config_currentlimits(const EOnv* nv, const eOropdescriptor_t* rd);

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 20 };
+enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 21 };
 
 enum { eoprot_entities_mc_numberof = eomc_entities_numberof };
 

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_fun.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_fun.c
@@ -149,6 +149,20 @@ EO_weak extern void eoprot_fun_INIT_mc_joint_config_pidtorque(const EOnv* nv) {}
 EO_weak extern void eoprot_fun_UPDT_mc_joint_config_pidtorque(const EOnv* nv, const eOropdescriptor_t* rd) {}
 #endif
    
+#if !defined(OVERRIDE_eoprot_fun_INIT_mc_motor_config_pidcurrent)
+EO_weak extern void eoprot_fun_INIT_mc_motor_config_pidcurrent(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_mc_motor_config_pidcurrent)
+EO_weak extern void eoprot_fun_UPDT_mc_motor_config_pidcurrent(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+    
+#if !defined(OVERRIDE_eoprot_fun_INIT_mc_motor_config_pidspeed)
+EO_weak extern void eoprot_fun_INIT_mc_motor_config_pidspeed(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_mc_motor_config_pidspeed)
+EO_weak extern void eoprot_fun_UPDT_mc_motor_config_pidspeed(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+    
 #if !defined(OVERRIDE_eoprot_fun_INIT_mc_joint_config_userlimits)
 EO_weak extern void eoprot_fun_INIT_mc_joint_config_userlimits(const EOnv* nv) {}
 #endif

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_rom.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_rom.c
@@ -132,10 +132,10 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config =
 
 static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config_pidposition =
 {   
-    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.config.pidposition),
-    EO_INIT(.rwmode)    eoprot_rwm_mc_joint_config_pidposition,
+    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.config.pidtrajectory),
+    EO_INIT(.rwmode)    eoprot_rwm_mc_joint_config_pidtrajectory,
     EO_INIT(.dummy)     0,    
-    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_joint_defaultvalue.config.pidposition,
+    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_joint_defaultvalue.config.pidtrajectory,
 #ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
     EO_INIT(.init)      NULL,
     EO_INIT(.update)    NULL
@@ -148,10 +148,10 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config_pidpositio
 
 static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config_pidvelocity =
 {   
-    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.config.pidvelocity),
-    EO_INIT(.rwmode)    eoprot_rwm_mc_joint_config_pidvelocity,
+    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.config.piddirect),
+    EO_INIT(.rwmode)    eoprot_rwm_mc_joint_config_piddirect,
     EO_INIT(.dummy)     0,    
-    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_joint_defaultvalue.config.pidvelocity,
+    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_joint_defaultvalue.config.piddirect,
 #ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
     EO_INIT(.init)      NULL,
     EO_INIT(.update)    NULL
@@ -177,6 +177,35 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config_pidtorque 
 #endif
 };
 
+static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_motor_config_pidcurrent =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_motor_defaultvalue.config.pidcurrent),
+    EO_INIT(.rwmode)    eoprot_rwm_mc_motor_config_pidcurrent,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_motor_defaultvalue.config.pidcurrent,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_mc_motor_config_pidcurrent,
+    EO_INIT(.update)    eoprot_fun_UPDT_mc_motor_config_pidcurrent
+#endif
+};
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_motor_config_pidspeed =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_motor_defaultvalue.config.pidspeed),
+    EO_INIT(.rwmode)    eoprot_rwm_mc_motor_config_pidspeed,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_motor_defaultvalue.config.pidspeed,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_mc_motor_config_pidspeed,
+    EO_INIT(.update)    eoprot_fun_UPDT_mc_motor_config_pidspeed
+#endif
+};
 
 static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_config_userlimits =
 {   
@@ -704,6 +733,8 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_mc_rom_motor_descriptors[] =
     &eoprot_mc_rom_descriptor_motor_config_rotorencoder,
     &eoprot_mc_rom_descriptor_motor_config_pwmlimit,
     &eoprot_mc_rom_descriptor_motor_config_temperaturelimit,
+    &eoprot_mc_rom_descriptor_motor_config_pidcurrent,
+    &eoprot_mc_rom_descriptor_motor_config_pidspeed,
     &eoprot_mc_rom_descriptor_motor_status,
     &eoprot_mc_rom_descriptor_motor_status_basic   
 };  EO_VERIFYsizeof(s_eoprot_mc_rom_motor_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_mc_motor_numberof));
@@ -798,6 +829,8 @@ static const char * const s_eoprot_mc_strings_tags_motor[] =
     "eoprot_tag_mc_motor_config_rotorencoder", 
     "eoprot_tag_mc_motor_config_pwmlimit",
     "eoprot_tag_mc_motor_config_temperaturelimit",
+    "eoprot_tag_mc_motor_config_pidcurrent",
+    "eoprot_tag_mc_motor_config_pidspeed",
     "eoprot_tag_mc_motor_status",
     "eoprot_tag_mc_motor_status_basic"
 };  EO_VERIFYsizeof(s_eoprot_mc_strings_tags_motor, eoprot_tags_mc_motor_numberof*sizeof(const char*)) 


### PR DESCRIPTION
This icub-firmware + icub-firmware-shared + icub-main package allows to configure the input of the 2FOC motor board (pwm, current, velocity) for each EMS control mode.