### PR TITLE
embot::prot::eth

### DIFF
--- a/embot/prot/eth/embot_prot_eth.h
+++ b/embot/prot/eth/embot_prot_eth.h
@@ -1,0 +1,172 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - brief
+//   it contains types of the eth protocol used inside icub: the rop 
+//
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_H_
+#define _EMBOT_PROT_ETH_H_
+
+#include "embot_core.h"
+#include "embot_core_utils.h"
+
+
+namespace embot { namespace prot { namespace eth {
+
+    
+    struct IPv4
+    {
+        uint32_t v {0};
+        IPv4() = default;
+        constexpr IPv4(uint32_t i) : v(i) {}
+        constexpr IPv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d) : v((a<<24)|(b<<16)|(c<<8)|(d)) {}
+        constexpr IPv4(const char *str) { 
+            v = 0;
+            if(nullptr == str) { return; }
+            uint8_t a{0}; uint8_t b{0}; uint8_t c{0}; uint8_t d{0}; 
+            if(4 == std::sscanf(str, "%hhi.%hhi.%hhi.%hhi", &a, &b, &c, &d)) 
+            {
+                v = ((a<<24)|(b<<16)|(c<<8)|(d)); 
+            }    
+        }
+        constexpr char * tostring(char *s, size_t size) const { 
+            if(nullptr != s) { std::snprintf(s, size, "%d.%d.%d.%d", v>>24, (v>>16)&0xff, (v>>8)&0xff, (v)&0xff); }
+            return s;
+        }
+    };
+
+    using Endpoint = std::uint8_t;
+    using Entity = std::uint8_t;
+    using Index = std::uint8_t;
+    using Tag = std::uint8_t;
+
+    constexpr uint8_t none08 = 0xff;
+    constexpr uint8_t unknown08 = 0xfe;
+
+    enum class EP : uint8_t { management = 0, motioncontrol = 1, analogsensors = 2, skin = 3, max = skin, unknown = unknown08, none = none08 }; 
+    static constexpr uint8_t maxValueOfEP = embot::core::tointegral(EP::max);
+    
+    enum class EN : uint8_t { 
+        // EP::management
+        mnComm = 0, mnApp = 1, mnInfo = 2, mnService = 3, mnMax = mnService,
+        // EP::motioncontrol
+        mcJoint = 0, mcMotor = 1, mcController = 2, mcMax = mcController,
+        // EP::analogsensors
+        asStrain = 0, asMais = 1, asTemperature = 2, asInertialLegacy = 3, asInertial3 = 4, asIMU = 4, asPSC = 5, asMax = asPSC,
+        // EP::skin
+        skSkinPatch = 0, skMax = skSkinPatch,
+        // commons
+        unknown = unknown08, none = none08
+    }; 
+    static constexpr uint8_t maxValueOfENs = embot::core::tointegral(EN::asMax);
+    
+    static constexpr uint8_t maxvEN = 5;
+       
+    using ID32 = std::uint32_t;
+
+    constexpr ID32 getID32(EP ep, EN en, Index i, Tag t)
+    {
+        return ((static_cast<uint32_t>(ep) << 24) | (static_cast<uint32_t>(en) << 16) | (static_cast<uint32_t>(i&0xff) << 8) | (static_cast<uint32_t>(t&0xff) << 0));
+    }
+
+    constexpr ID32 ID32none = getID32(EP::none, EN::none, none08, none08); // 0xffffffff
+
+    constexpr EP getEP(ID32 id32)
+    {
+        uint8_t x = (id32 >> 24) & 0xff;
+        return ((x <= embot::core::tointegral(EP::max)) || (x == embot::core::tointegral(EP::none))) ? (static_cast<EP>(x)) : (EP::unknown);
+    }
+
+#if 0
+    // this code requires c++17
+    constexpr EN getEN(ID32 id32)
+    {
+        EN en = EN::unknown;
+        EP ep = getEP(id32);
+        uint8_t x = (id32 >> 16) & 0xff;
+        auto sel = [](uint8_t v, EN m) { return ((v <= embot::core::tointegral(m)) || (v == embot::core::tointegral(EN::none))) ? (static_cast<EN>(v)) : (EN::unknown); }; 
+        switch(ep)
+        {
+            case EP::management:
+            {
+                en = sel(x, EN::mnMax);
+            } break;
+
+            case EP::motioncontrol:
+            {
+                en = sel(x, EN::mcMax);
+            } break;
+
+            case EP::analogsensors:
+            {
+                en = sel(x, EN::asMax);
+            } break;           
+
+            case EP::skin:
+            {
+                en = sel(x, EN::skMax);
+            } break;   
+
+            case EP::none:
+            {
+                en = EN::none;
+            } break;
+
+            case EP::unknown:
+            default:
+            {
+            } break;
+
+        }
+        return en;
+    }
+#else
+    // hence we use this version with a rom-mapped LUT
+    constexpr EN getEN(ID32 id32)
+    {
+        EN en = EN::unknown;
+        EP ep = getEP(id32);
+        constexpr EN lut[maxValueOfEP+1][maxValueOfENs+1] = 
+        { 
+            {EN::mnComm, EN::mnApp, EN::mnInfo, EN::mnService, EN::unknown, EN::unknown}, 
+            {EN::mcJoint, EN::mcMotor, EN::mcController, EN::unknown, EN::unknown, EN::unknown}, 
+            {EN::asStrain, EN::asMais, EN::asTemperature, EN::asInertialLegacy, EN::asIMU, EN::asPSC},
+            {EN::skSkinPatch, EN::unknown, EN::unknown, EN::unknown, EN::unknown, EN::unknown} 
+        };
+        if((EP::none != ep) && (EP::unknown != ep))
+        {
+            uint8_t x = (id32 >> 16) & 0xff;
+            if(x <= maxValueOfENs)
+            {
+                en = lut[embot::core::tointegral(ep)][x];
+            }
+        }
+ 
+        return en;
+    }
+#endif
+
+    constexpr Index getIndex(ID32 id32)
+    {
+        return (id32 >> 8) & 0xff;
+    }
+
+    constexpr Tag getTag(ID32 id32)
+    {
+        return (id32) & 0xff;
+    }
+
+}}} // namespace embot { namespace prot { namespace eth {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/embot/prot/eth/embot_prot_eth_diagnostic.h
+++ b/embot/prot/eth/embot_prot_eth_diagnostic.h
@@ -1,0 +1,142 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - brief
+//   it contains types of the eth protocol used inside icub: the rop 
+//
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_DIAGNOSTIC_H_
+#define _EMBOT_PROT_ETH_DIAGNOSTIC_H_
+
+#include "embot_core.h"
+#include "embot_core_binary.h"
+#include "embot_core_utils.h"
+#include "embot_prot_eth.h"
+
+
+namespace embot { namespace prot { namespace eth { namespace diagnostic {
+    
+    constexpr embot::prot::eth::Tag tag_wholeitem = 0;
+    constexpr embot::prot::eth::Tag tag_config = 1;  
+    constexpr embot::prot::eth::Tag tag_config_enable = 2;  
+    constexpr embot::prot::eth::Tag tag_info = 3;  
+    constexpr embot::prot::eth::Tag tag_info_basic = 4;  
+    constexpr embot::prot::eth::Tag tag_infolarge = 5;
+    
+    
+    struct Config
+    {
+        // -> memory layout
+        uint8_t enable {1};
+        uint8_t filler[7] {0};
+        // <- memory layout
+        
+        Config() = default;
+        
+        constexpr static uint16_t sizeofobject = 8;
+    }; static_assert(sizeof(Config) == Config::sizeofobject, "embot::prot::eth::diagnostic::Config has wrong sizeofobject. it must be 2");
+    
+        
+    // 16 bits -> FFU(4) | EXT(2) | ADR(4) | SRC(3) | TYP(3) 
+    enum class TYP : uint16_t { info = 0, debug = 1, warning = 2, error = 3, fatal = 4, max = 7 }; // uses 3 bits -> up to value = 7
+    enum class SRC : uint16_t { board = 0, can1 = 1, can2 = 2, max  = 7 }; // uses 3 bits -> up to value = 7 
+    enum class ADR : uint16_t { zero = 0, one = 1, two, three, four, five, six, seven, eigth, nine, ten, eleven, twelve, thirteen, fourteen, fifteen = 15, max = 15 };
+    enum class EXT : uint16_t { none = 0, verbal = 1, compact1 = 2, max = 3 }; // uses 2 bits -> up to value = 3
+    enum class FFU : uint16_t { none = 0, max = 15 };
+
+    struct InfoProperties 
+    {
+        // -> memory layout
+        uint16_t flags {0};
+        // <- memory layout
+        
+        InfoProperties() = default;
+        
+        constexpr InfoProperties(TYP t, SRC s, ADR a, EXT e, FFU f = FFU::none) : flags(load(t, s, a, e, f)) {}
+        
+        // legacy ...
+        constexpr InfoProperties(uint16_t fl) : flags(fl) {}
+                
+        constexpr uint16_t load(TYP t, SRC s, ADR a, EXT e, FFU f = FFU::none)
+        {
+            flags = (embot::core::tointegral(t)) | (embot::core::tointegral(s) << 3) | 
+                    (embot::core::tointegral(a) << 6) | (embot::core::tointegral(e) << 10) | (embot::core::tointegral(f) << 12);
+            return flags;
+        }
+        
+        constexpr TYP getTYP() const { return static_cast<TYP>((flags>>0)&0x7); }
+        constexpr SRC getSRC() const { return static_cast<SRC>((flags>>3)&0x7); }
+        constexpr ADR getADR() const { return static_cast<ADR>((flags>>6)&0xf); }
+        constexpr EXT getEXT() const { return static_cast<EXT>((flags>>10)&0x3); }
+        constexpr FFU getFFU() const { return static_cast<FFU>((flags>>12)&0xf); }        
+               
+        constexpr static uint16_t sizeofobject = 2;
+    }; static_assert(sizeof(InfoProperties) == InfoProperties::sizeofobject, "embot::prot::eth::diagnostic::InfoProperties has wrong sizeofobject. it must be 2");
+    
+    
+    struct InfoBasic
+    {
+        // -> memory layout
+        embot::core::Time timestamp {0};
+        uint32_t code {0};
+        InfoProperties flags { TYP::info, SRC::board, ADR::zero, EXT::none }; 
+        uint16_t par16 {0};
+        uint64_t par64 {0};
+        // <- memory layout
+
+        // methods
+        InfoBasic() = default;
+        constexpr InfoBasic(embot::core::Time t, uint32_t c, InfoProperties p, uint16_t p16, uint64_t p64) : timestamp(t), code(c), flags(p), par16(p16), par64(p64) {}
+        // constexpr bool load(void *rawmemory) { if(nullptr == rawmemory) { return false; } std::memmove(this, rawmemory, sizeofobject); return true; }
+        constexpr static embot::prot::eth::ID32 id32 = embot::prot::eth::getID32(embot::prot::eth::EP::management, embot::prot::eth::EN::mnInfo, 0, tag_info_basic);
+        constexpr static uint16_t sizeofobject = 24;
+    };  static_assert(sizeof(InfoBasic) == InfoBasic::sizeofobject, "embot::prot::eth::diagnostic::InfoBasic has wrong sizeofobject. it must be 24");
+
+    
+    struct Info
+    {
+        constexpr static uint16_t extrasizeof = 48; 
+        
+        // -> memory layout
+        InfoBasic basic {};
+        uint8_t extra[extrasizeof] {0};  
+        // -> memory layout
+        
+        // methods
+        Info() =  default;
+        constexpr Info(const InfoBasic &b, const void *e = nullptr) : basic(b) { if(nullptr != e) { std::memmove(extra, e, sizeof(extra)); } }    
+        constexpr static embot::prot::eth::ID32 id32 = embot::prot::eth::getID32(embot::prot::eth::EP::management, embot::prot::eth::EN::mnInfo, 0, tag_info);
+        constexpr static uint16_t sizeofobject = 72;        
+    };  static_assert(sizeof(Info) == Info::sizeofobject, "embot::prot::eth::diagnostic::Info has wrong sizeofobject. it must be 72");
+
+
+    struct InfoLarge
+    {
+        constexpr static uint16_t extrasizeof = 224;
+
+        // -> memory layout
+        InfoBasic basic {};
+        uint8_t extral[extrasizeof] {0};
+        // -> memory layout
+
+        // methods
+        InfoLarge() = default;
+        constexpr InfoLarge(const InfoBasic &b, const void *e = nullptr) : basic(b) { if(nullptr != e) { std::memmove(extral, e, sizeof(extral)); } }
+        constexpr static embot::prot::eth::ID32 id32 = embot::prot::eth::getID32(embot::prot::eth::EP::management, embot::prot::eth::EN::mnInfo, 0, tag_infolarge);
+        constexpr static uint16_t sizeofobject = 248;
+    };  static_assert(sizeof(InfoLarge) == InfoLarge::sizeofobject, "embot::prot::eth::diagnostic::InfoLarge has wrong sizeofobject. it must be 248");
+
+
+}}}} // namespace embot { namespace prot { namespace eth { namespace diagnostic {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/embot/prot/eth/embot_prot_eth_diagnostic_Host.cpp
+++ b/embot/prot/eth/embot_prot_eth_diagnostic_Host.cpp
@@ -1,0 +1,178 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_prot_eth_diagnostic_Host.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_prot_eth_ropframe.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+struct embot::prot::eth::diagnostic::Host::Impl
+{    
+    Config config {};    
+    bool initted {false}; 
+
+    embot::prot::eth::ropframe::Parser *_ropframeparser {nullptr};
+    embot::prot::eth::rop::Descriptor ropdes {};
+    
+    // it should be a map<ipv4, uint64_t>
+    uint64_t rxsequencenumber {0};
+
+    
+    Impl() = default;   
+
+    ~Impl()
+    {
+        constexpr bool force = true;
+        deinit(force);
+    }
+
+    bool deinit(bool force = false)
+    {
+        if(!force)
+        {
+            if(!initted)
+            {
+                return false;
+            }
+        }
+
+        if(nullptr != _ropframeparser)
+        {
+            delete _ropframeparser;
+            _ropframeparser = nullptr;
+        }
+        
+        initted = false;
+
+        return true;
+    }
+
+    bool init(const Config &c)
+    {
+        if(initted)
+        {
+            return false;
+        }
+
+        config = c;
+
+        _ropframeparser = new embot::prot::eth::ropframe::Parser; // created, but it is an empty shell which will point to the accepted ropframe
+        
+        initted = true;
+        return true;
+    }
+    
+    
+//    bool load(EOrop* rop, embot::prot::eth::rop::Descriptor &ropdes)
+//    {
+//        ropdes.reset();
+//        eOropdescriptor_t *rd = &rop->ropdes;
+//        ropdes.opcode = (rd->ropcode <= eo_ropcode_sig) ? static_cast<embot::prot::eth::rop::OPC>(rd->ropcode) : embot::prot::eth::rop::OPC::none;
+//        ropdes.id32 = rd->id32;
+//        if(0 != rd->size)
+//        {
+//            ropdes.value.load(rd->data, rd->size);         
+//        }
+//        
+//        return true;
+//    }        
+
+
+    bool accept(const embot::prot::eth::IPv4 &ipv4, const embot::core::Data &ropframedata, embot::prot::eth::rop::fpOnROP onrop = nullptr)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+
+        if(!ropframedata.isvalid())
+        {
+            return false;
+        }
+
+        // load data into the ropframe
+        _ropframeparser->load(ropframedata);        
+
+        // check validity
+        if(false == _ropframeparser->isvalid())
+        {
+            _ropframeparser->unload();
+            return false;
+        }
+
+        // check sequence number ... from each ip address, so ... maybe a map. but not in here
+        
+        uint64_t rxsequencenumber = _ropframeparser->getSequenceNumber();
+        
+        // and parse
+        uint16_t numberofprocessed = 0;
+        if(nullptr == onrop)
+        {
+            onrop = config.onrop;
+        }
+        bool r = _ropframeparser->parse(ipv4, onrop, numberofprocessed);        
+        return r;
+    }
+};
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+embot::prot::eth::diagnostic::Host::Host()
+: pImpl(new Impl)
+{ 
+}
+
+embot::prot::eth::diagnostic::Host::~Host()
+{   
+    delete pImpl;
+}
+
+
+bool embot::prot::eth::diagnostic::Host::initted() const
+{
+    return pImpl->initted;
+}
+
+
+bool embot::prot::eth::diagnostic::Host::init(const Config &config)
+{       
+    if(true == initted())
+    {
+        return false;
+    }
+
+    return pImpl->init(config);        
+}
+
+
+bool embot::prot::eth::diagnostic::Host::accept(const embot::prot::eth::IPv4 &ipv4, const embot::core::Data &ropframedata, embot::prot::eth::rop::fpOnROP onrop)
+{
+    return pImpl->accept(ipv4, ropframedata, onrop);
+}
+
+    
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/embot/prot/eth/embot_prot_eth_diagnostic_Host.h
+++ b/embot/prot/eth/embot_prot_eth_diagnostic_Host.h
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_DIAGNOSTIC_HOST_H_
+#define _EMBOT_PROT_ETH_DIAGNOSTIC_HOST_H_
+
+#include "embot_core.h"
+#include "embot_core_utils.h"
+#include "embot_prot_eth_rop.h"
+
+namespace embot { namespace prot { namespace eth { namespace diagnostic {
+           
+    class Host 
+    {
+    public:
+        struct Config
+        {
+            bool concurrentuse {false};
+            size_t ropcapacity {128};
+            embot::prot::eth::rop::fpOnROP onrop {nullptr};
+            Config() = default;
+            constexpr Config(bool cu, size_t rc, embot::prot::eth::rop::fpOnROP o) 
+               : concurrentuse(cu), ropcapacity(rc), onrop(o) {}
+            bool isvalid() const { return (!onrop) && (ropcapacity >= 40); }
+        };         
+               
+        Host();  
+        ~Host();
+
+        // usage: init(), then accept(ipv4, rxropframe). 
+
+        bool init(const Config &config);
+        bool initted() const;
+        bool accept(const embot::prot::eth::IPv4 &ipv4, const embot::core::Data &ropframedata, embot::prot::eth::rop::fpOnROP onrop = nullptr);  
+    
+    private:    
+        struct Impl;
+        Impl *pImpl;
+    };  
+    
+
+}}}} // namespace embot { namespace prot { namespace eth { namespace diagnostic {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/embot/prot/eth/embot_prot_eth_diagnostic_Node.cpp
+++ b/embot/prot/eth/embot_prot_eth_diagnostic_Node.cpp
@@ -1,0 +1,470 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_prot_eth_diagnostic_Node.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+
+#include "embot_prot_eth_rop.h"
+#include "embot_prot_eth_ropframe.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+struct embot::prot::eth::diagnostic::Node::Impl
+{    
+    Config config {};    
+    bool initted {false}; 
+
+    embot::prot::eth::ropframe::Former *_ropframeformer {nullptr};
+    // used by _ropframeformer
+    uint8_t *ropframedata {nullptr};
+    embot::core::Data buffer {nullptr, 0};
+    uint8_t *bufferdata {nullptr};
+    size_t buffercapacity {0};
+    uint64_t sequencenumber {0};
+    // used by _ropframeformer
+    embot::prot::eth::rop::Stream *_ropstream {nullptr};
+   
+    // preformed ropstream for Info & InfoBasic     
+    embot::prot::eth::rop::Stream *ropstr_infolarge {nullptr};
+    embot::prot::eth::rop::Stream *ropstr_info {nullptr};
+    embot::prot::eth::rop::Stream *ropstr_infobasic {nullptr};
+    
+    
+    Impl() = default;   
+
+    ~Impl()
+    {
+        constexpr bool force = true;
+        deinit(force);
+    }
+
+    bool deinit(bool force = false)
+    {
+        if(!force)
+        {
+            if(!initted)
+            {
+                return false;
+            }
+        }
+
+        if(nullptr != bufferdata)
+        {
+            delete[] bufferdata;
+            bufferdata = nullptr;
+            buffercapacity = 0;
+        }
+
+        if(nullptr != ropframedata)
+        {
+            delete[] ropframedata;
+            ropframedata = nullptr;
+        }
+
+        if(nullptr != _ropframeformer)
+        {
+            //eo_ropframe_Delete(ropframe);
+            delete _ropframeformer;
+            _ropframeformer = nullptr;
+        }
+
+        if(nullptr != ropstr_infolarge)
+        {
+            delete ropstr_infolarge;
+            ropstr_infolarge = nullptr;
+        }
+
+        if(nullptr != ropstr_info)
+        {
+            delete ropstr_info;
+            ropstr_info = nullptr;
+        }       
+        
+        if(nullptr != ropstr_infobasic)
+        {
+            delete ropstr_infobasic;
+            ropstr_infobasic = nullptr;
+        }
+        
+        if(nullptr != _ropstream)
+        {
+            delete _ropstream;
+            _ropstream =  nullptr;
+        }
+
+        initted = false;
+
+        return true;
+    }
+
+    bool init(const Config &c)
+    {
+        if(initted)
+        {
+            return false;
+        }
+       
+        if(false == c.isvalid())
+        {
+            return false;
+        }
+        
+        config = c;
+        _ropframeformer = new embot::prot::eth::ropframe::Former; // empty shell
+        uint16_t nbytes4frame = config.ropframecapacity;
+        ropframedata = new uint8_t[nbytes4frame];
+        // give memory to the empty shell, so that it contains the header-ropspace-footer + a service ropstream
+        _ropstream = new embot::prot::eth::rop::Stream(config.singleropstreamcapacity);
+        _ropframeformer->load({ropframedata, nbytes4frame}, _ropstream);         
+        // and give memory to my buffer
+        buffercapacity = nbytes4frame;
+        bufferdata = new uint8_t[buffercapacity];
+        buffer.clear(); // so that it is not valid
+        
+        
+        constexpr embot::prot::eth::rop::PLUS plusMODE = embot::prot::eth::rop::PLUS::none;
+        constexpr embot::prot::eth::rop::SIGN signature = embot::prot::eth::rop::signatureNone;
+        constexpr embot::core::Time time = embot::core::timeNone;
+        
+        // also, i need a predefined rop able to host the sig<> of a full embot::prot::eth::diagnostic::InfoBasic w/out signature and time    
+        ropstr_infobasic = new embot::prot::eth::rop::Stream(embot::prot::eth::rop::Stream::capacityfor(embot::prot::eth::rop::OPC::any, embot::prot::eth::diagnostic::InfoBasic::sizeofobject, plusMODE));         
+        constexpr embot::prot::eth::rop::Descriptor sig_infobasic {
+            embot::prot::eth::rop::OPC::sig, 
+            embot::prot::eth::diagnostic::InfoBasic::id32, 
+            embot::core::Data{nullptr, embot::prot::eth::diagnostic::InfoBasic::sizeofobject},
+            signature, time,
+            plusMODE
+        };      
+        ropstr_infobasic->load(sig_infobasic);
+        
+
+        // also, i need a predefined rop able to host the sig<> of a full embot::prot::eth::diagnostic::Info w/out signature and time    
+        ropstr_info = new embot::prot::eth::rop::Stream(embot::prot::eth::rop::Stream::capacityfor(embot::prot::eth::rop::OPC::any, embot::prot::eth::diagnostic::Info::sizeofobject, plusMODE));         
+        constexpr embot::prot::eth::rop::Descriptor sig_info {
+            embot::prot::eth::rop::OPC::sig, 
+            embot::prot::eth::diagnostic::Info::id32, 
+            embot::core::Data{nullptr, embot::prot::eth::diagnostic::Info::sizeofobject},
+            signature, time,
+            plusMODE
+        };      
+        ropstr_info->load(sig_info);        
+
+        // also, i need a predefined rop able to host the sig<> of a full embot::prot::eth::diagnostic::InfoLarge w/out signature and time
+        ropstr_infolarge = new embot::prot::eth::rop::Stream(embot::prot::eth::rop::Stream::capacityfor(embot::prot::eth::rop::OPC::any, embot::prot::eth::diagnostic::InfoLarge::sizeofobject, plusMODE));
+        constexpr embot::prot::eth::rop::Descriptor sig_infolarge {
+            embot::prot::eth::rop::OPC::sig,
+            embot::prot::eth::diagnostic::InfoLarge::id32,
+            embot::core::Data{nullptr, embot::prot::eth::diagnostic::InfoLarge::sizeofobject},
+            signature, time,
+            plusMODE
+        };
+        ropstr_infolarge->load(sig_infolarge);
+        initted = true;
+        return true;
+    }
+
+    bool add(const embot::core::Data &ropstream)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+
+        if(!ropstream.isvalid())
+        {
+            return false;
+        }
+
+        uint16_t availspace = 0;
+        return _ropframeformer->pushback(ropstream, availspace);
+    }
+
+
+    bool add(const embot::prot::eth::rop::Descriptor &ropdes)
+    {
+        if(!initted)
+        {
+            return false;
+        }    
+
+        if(!ropdes.isvalid())
+        {
+            return false;
+        }        
+          
+        uint16_t availspace = 0;
+        return _ropframeformer->pushback(ropdes, availspace);
+        return false;
+    }
+    
+
+    bool add(const embot::prot::eth::diagnostic::InfoBasic &infobasic)
+    {
+        if(!initted)
+        {
+            return false;
+        }        
+        // i need a pre-former rop (or ropstream) where to just add the infobasic stuff
+        embot::core::Data da{const_cast<embot::prot::eth::diagnostic::InfoBasic*>(&infobasic), embot::prot::eth::diagnostic::InfoBasic::sizeofobject};
+        //embot::core::Data da{&infobasic, embot::prot::eth::diagnostic::InfoBasic::size};
+        static uint32_t sig = 0;
+        ropstr_infobasic->update(da, sig++);
+        
+        uint8_t *strm = nullptr;
+        size_t ss = 0;
+        ropstr_infobasic->retrieve(&strm, ss);
+
+        uint16_t availspace = 0;
+        return _ropframeformer->pushback({strm, ss}, availspace);
+    }
+
+    bool add(const embot::prot::eth::diagnostic::Info &info)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+
+        embot::prot::eth::rop::Stream *stream = (embot::prot::eth::diagnostic::EXT::none == info.basic.flags.getEXT()) ? ropstr_infobasic : ropstr_info;        
+        
+        // i need a pre-former rop (or ropstream) where to just add the info stuff
+        embot::core::Data da{const_cast<embot::prot::eth::diagnostic::Info*>(&info), embot::prot::eth::diagnostic::Info::sizeofobject};
+        static uint32_t sig = 0;
+        stream->update(da, sig++);
+        
+        uint8_t *strm = nullptr;
+        size_t ss = 0;
+        stream->retrieve(&strm, ss);
+
+        uint16_t availspace = 0;
+        return _ropframeformer->pushback({strm, ss}, availspace);
+    }
+
+    bool add(const embot::prot::eth::diagnostic::InfoLarge &infolarge)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+        
+        embot::prot::eth::rop::Stream *stream = (embot::prot::eth::diagnostic::EXT::none == infolarge.basic.flags.getEXT()) ? ropstr_infobasic : ropstr_infolarge; 
+
+        // i need a pre-former rop (or ropstream) where to just add the infobasic stuff
+        embot::core::Data da{const_cast<embot::prot::eth::diagnostic::InfoLarge*>(&infolarge), embot::prot::eth::diagnostic::InfoLarge::sizeofobject};
+        static uint32_t sig = 0;
+        stream->update(da, sig++);
+
+        uint8_t *strm = nullptr;
+        size_t ss = 0;
+        stream->retrieve(&strm, ss);
+
+        uint16_t availspace = 0;
+        return _ropframeformer->pushback({strm, ss}, availspace);
+    }
+    
+    bool prepare(size_t &sizeofropframe)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+
+        // prepare the ropframe. but only if it is not empty. 
+        // after preparation clear it
+
+        sizeofropframe = 0;
+#if 1
+        if(0 == _ropframeformer->getNumberOfROPs())
+        {
+            return false;
+        }   
+
+        embot::core::Time timenow = embot::core::now();
+        _ropframeformer->set(timenow, sequencenumber++);
+        
+        // copy into buffer
+        embot::core::Data fr {};
+        _ropframeformer->get(fr); 
+        std::memmove(bufferdata, fr.pointer, fr.capacity); 
+        buffer.load(bufferdata, fr.capacity); // now buffer is valid ...        
+        
+        sizeofropframe = fr.capacity;
+        // format
+        _ropframeformer->format();
+            
+        return true;
+        
+#else
+        if(0 == eo_ropframe_ROP_NumberOf(ropframe))
+        {   // dont transmit: we dont have rops
+            return false;
+        }
+        
+        // if we have rops ...
+        // 1. add a valid timestamp
+        // 2. increment the sequence number
+        // 3. copy the ropframe inside a buffer
+        // 4. and finally clear the ropframe so that it will be able to load new rops
+        // 1.
+        eOabstime_t timenow = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+        eo_ropframe_age_Set(ropframe, timenow);
+        
+        // 2.
+        eo_ropframe_seqnum_Set(ropframe, sequencenumber);
+        sequencenumber++;
+        
+        // 3.
+        uint8_t *fdata = NULL;
+        uint16_t fsize = 0;
+        uint16_t fcapacity = 0;
+        
+        eo_ropframe_Get(ropframe, &fdata, &fsize, &fcapacity);
+        // fcapacity is surely bigger equal than buffercapacity (i allocated them myself), hence i dont check
+        // copy the ropframe into the buffer
+        std::memmove(bufferdata, fdata, fsize); 
+        buffer.load(bufferdata, fsize); // now buffer is valid ...
+        
+        // 4.
+        eo_ropframe_Clear(ropframe);  
+
+        sizeofropframe = fsize;
+        return true;
+#endif        
+    }
+
+    bool retrieve(embot::core::Data &datainropframe)
+    {
+        if(!initted)
+        {
+            return false;
+        }
+
+        if(!datainropframe.isvalid())
+        {
+            return false;
+        }
+
+        // in here i could lock buffer ..
+
+        if(!buffer.isvalid())
+        {
+            return false;
+        }
+
+        if(datainropframe.capacity < buffer.capacity)
+        {
+            return false;
+        }
+
+        // i am ok: i can copy buffer into ropframe
+
+        datainropframe.capacity = buffer.capacity;
+        std::memmove(datainropframe.pointer, buffer.pointer, buffer.capacity); 
+
+        // ok, i could unlock
+
+        return true;
+    }
+    
+    uint16_t getNumberOfROPs() const
+    {
+        return _ropframeformer->getNumberOfROPs();
+    }
+
+};
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+embot::prot::eth::diagnostic::Node::Node()
+: pImpl(new Impl)
+{ 
+}
+
+embot::prot::eth::diagnostic::Node::~Node()
+{   
+    delete pImpl;
+}
+
+
+bool embot::prot::eth::diagnostic::Node::initted() const
+{
+    return pImpl->initted;
+}
+
+
+bool embot::prot::eth::diagnostic::Node::init(const Config &config)
+{       
+    if(true == initted())
+    {
+        return false;
+    }
+
+    return pImpl->init(config);        
+}
+
+
+bool embot::prot::eth::diagnostic::Node::add(const embot::core::Data &ropstream)
+{
+    return pImpl->add(ropstream);
+}
+
+bool embot::prot::eth::diagnostic::Node::add(const embot::prot::eth::rop::Descriptor &ropdes)
+{
+    return pImpl->add(ropdes);
+}
+
+bool embot::prot::eth::diagnostic::Node::add(const embot::prot::eth::diagnostic::InfoBasic &infobasic)
+{
+    return pImpl->add(infobasic);    
+}
+
+bool embot::prot::eth::diagnostic::Node::add(const embot::prot::eth::diagnostic::Info &info)
+{
+    return pImpl->add(info);    
+}
+
+bool embot::prot::eth::diagnostic::Node::add(const embot::prot::eth::diagnostic::InfoLarge &infolarge)
+{
+    return pImpl->add(infolarge);
+}
+
+bool embot::prot::eth::diagnostic::Node::prepare(size_t &sizeofropframe)
+{
+    return pImpl->prepare(sizeofropframe);
+}
+
+
+bool embot::prot::eth::diagnostic::Node::retrieve(embot::core::Data &datainropframe)
+{
+    return pImpl->retrieve(datainropframe);
+}
+
+uint16_t embot::prot::eth::diagnostic::Node::getNumberOfROPs() const
+{
+    return pImpl->getNumberOfROPs();
+}
+    
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/embot/prot/eth/embot_prot_eth_diagnostic_Node.h
+++ b/embot/prot/eth/embot_prot_eth_diagnostic_Node.h
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - brief
+//   it contains pimpl class(es) for handling diagnostics in an ETH node
+//
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_DIAGNOSTIC_NODE_H_
+#define _EMBOT_PROT_ETH_DIAGNOSTIC_NODE_H_
+
+#include "embot_core.h"
+#include "embot_core_utils.h"
+#include "embot_prot_eth_rop.h"
+
+#include "embot_prot_eth_diagnostic.h"
+
+namespace embot { namespace prot { namespace eth { namespace diagnostic {
+           
+    class Node 
+    {
+    public:
+        struct Config
+        {
+            bool concurrentuse {false}; // ffu
+            uint16_t singleropstreamcapacity {128};
+            uint16_t ropframecapacity {512};
+            // todo: 
+            // - add any customisation such as: capacityofropframe, maxropsize, capacity of fifo of ropframes, etc.  
+            Config() = default;
+            constexpr Config(bool cu, uint16_t src, uint16_t rfc) : concurrentuse(cu), singleropstreamcapacity(src), ropframecapacity(rfc) {}
+            bool isvalid() const { return (ropframecapacity > (28+32)) && (singleropstreamcapacity > 32); }
+        };         
+               
+        Node();  
+        ~Node();
+
+        // usage: init(), then add() as many rops one wants, then when one wants to attempt transmit: 
+        // if(prepare()) { retrieve(data); <alert the sender>}
+
+        bool init(const Config &config);
+        bool initted() const;
+        bool add(const embot::core::Data &ropstream);
+        bool add(const embot::prot::eth::rop::Descriptor &ropdes); 
+        bool add(const embot::prot::eth::diagnostic::InfoBasic &infobasic);
+        bool add(const embot::prot::eth::diagnostic::Info &info);
+        bool add(const embot::prot::eth::diagnostic::InfoLarge &infolarge);
+        bool prepare(size_t &sizeofropframe); // returns true if anything to retrieve. in sizeofropframe the size of required mem
+        bool retrieve(embot::core::Data &datainropframe); // it copies the ropframe. 
+        uint16_t getNumberOfROPs() const;
+
+    private:    
+        struct Impl;
+        Impl *pImpl;
+    };  
+    
+
+}}}} // namespace embot { namespace prot { namespace eth { namespace diagnostic {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/embot/prot/eth/embot_prot_eth_rop.cpp
+++ b/embot/prot/eth/embot_prot_eth_rop.cpp
@@ -1,0 +1,246 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_prot_eth_rop.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include <algorithm>
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+
+struct embot::prot::eth::rop::Stream::Impl
+{    
+    uint8_t *stream {nullptr};
+    Header *ref2header {nullptr};
+    uint8_t *ref2data {nullptr};
+    size_t capacityofstream {0};
+    Descriptor descriptor {};
+    size_t sizeofstream {0};
+    
+    Impl(size_t capacity)
+    {
+        if(capacity < Stream::minimumsize)
+        {
+            capacity = Stream::minimumsize;
+        }
+        capacityofstream = (capacity+3)/4;
+        capacityofstream *= 4;
+        stream = new uint8_t[capacityofstream];
+        
+        ref2header = reinterpret_cast<Header*>(stream);
+        if(capacityofstream > Stream::minimumsize)
+        {
+            ref2data = stream + sizeof(Header);
+        }
+    }   
+
+    ~Impl()
+    {
+        delete[] stream;
+        // DONT delete ref2header or ref2data
+        //constexpr bool force = true;
+        //deinit(force);
+    }
+    
+    void fillheader(Header *header, const embot::prot::eth::rop::Descriptor &des)
+    {        
+        header->fmt.fill(des.plus, RQST::none, CONF::none);
+        header->opc = des.opcode;
+        header->datasize = (des.value.capacity+3)/4;
+        header->datasize *= 4;
+        header->id32 = des.id32;
+    }
+
+    bool load(const Descriptor &des)
+    {
+        size_t required = Stream::capacityfor(des.opcode, des.value.capacity, des.plus);
+        
+        if(required > capacityofstream)
+        {
+            return false;
+        }
+        
+        descriptor = des;
+        sizeofstream = required;
+        
+        // ok, now i shape the memory of the ropstream
+        
+        // header
+        fillheader(ref2header, des);
+        
+        // data
+        if(des.value.isvalid())
+        {   
+            uint16_t nbytes = std::min(ref2header->datasize, static_cast<uint16_t>(des.value.capacity));
+            std::memmove(ref2data, des.value.pointer, nbytes);
+        }
+        
+        // signature
+        if(des.hassignature())
+        {
+            std::memmove(ref2data+ref2header->datasize, &des.signature, sizeof(des.signature));
+        }   
+        
+        // time
+        if(des.hastime())
+        {   // DONT attempt to use uint64_t* from ref2data+ref2header->datasize+4 and do a direct assignment because the memory is not guarantted to be 8-aligned.
+            std::memmove(ref2data+ref2header->datasize+4, &des.time, sizeof(des.time));
+        }
+                     
+        return true;
+    }
+    
+    
+    bool retrieve(uint8_t **data, size_t &size)
+    {
+        if(nullptr == data)
+        {
+            return false;
+        }
+        
+        *data = stream;        
+        size = sizeofstream;
+        return true;
+    }
+ 
+    bool update(const embot::core::Data &data, const embot::prot::eth::rop::SIGN signature = embot::prot::eth::rop::signatureNone, const embot::core::Time time = embot::core::timeNone)
+    {
+        bool r = false;
+        
+        if(data.isvalid())
+        {
+            uint16_t nbytes = std::min(ref2header->datasize, static_cast<uint16_t>(data.capacity));
+            std::memmove(ref2data, data.pointer, nbytes);   
+            r = true;
+        }
+    
+        if((ref2header->fmt.isPLUSsignature()))
+        {
+            std::memmove(ref2data+ref2header->datasize, &signature, sizeof(signature));
+            r = true;
+        } 
+        
+        if((ref2header->fmt.isPLUStime()))
+        {
+            std::memmove(ref2data+ref2header->datasize+4, &time, sizeof(time));
+            r = true;
+        }
+        
+        return r;
+    }
+    
+    size_t getcapacity() const
+    {
+        return capacityofstream;
+    }
+
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+embot::prot::eth::rop::Stream::Stream(size_t capacity)
+: pImpl(new Impl(capacity))
+{ 
+
+}
+
+embot::prot::eth::rop::Stream::~Stream()
+{   
+    delete pImpl;
+}
+
+bool embot::prot::eth::rop::Stream::load(const Descriptor &des)
+{
+    return pImpl->load(des);
+}
+
+bool embot::prot::eth::rop::Stream::update(const embot::core::Data &data, const embot::prot::eth::rop::SIGN signature, const embot::core::Time time)
+{
+   return pImpl->update(data, signature, time);
+}
+
+bool embot::prot::eth::rop::Stream::retrieve(uint8_t **data, size_t &size)
+{
+    return pImpl->retrieve(data, size);
+}    
+
+size_t embot::prot::eth::rop::Stream::getcapacity() const
+{
+    return pImpl->getcapacity();
+}
+
+
+// - descriptor
+
+
+bool embot::prot::eth::rop::Descriptor::load(embot::core::Data &stream, uint16_t &consumed)
+{
+    reset();
+    consumed = 0;
+    if(false == stream.isvalid())
+    {
+        return false;
+    }
+    
+    if(stream.capacity < Header::sizeofobject)
+    {
+        return false;
+    }
+    
+    Header *rophead = reinterpret_cast<Header*>(stream.pointer);
+    
+    // now i need to see how big the ropstream is expected to be
+    size_t expectedsize = Stream::capacityfor(rophead->opc, rophead->datasize, rophead->fmt.getPLUS());
+    if((expectedsize > stream.capacity) || (0 != (rophead->datasize % 4))) // it was < ...
+    {
+        return false;
+    }
+    
+    // ok, we can consume the bytes
+    consumed = expectedsize;
+    
+    // and we fill the fields of the Descriptor
+    opcode = rophead->opc;
+    id32 = rophead->id32;
+    value.capacity = rophead->datasize;
+    value.pointer = (0 == value.capacity) ? nullptr : (stream.getU08ptr() + sizeof(Header));
+    uint16_t offset_time = 0;
+    if(rophead->fmt.isPLUSsignature())
+    {
+        offset_time = sizeof(signature);
+        std::memmove(&signature, stream.getU08ptr() + sizeof(Header) + rophead->datasize, sizeof(signature));
+    }
+    if(rophead->fmt.isPLUStime())
+    {
+        std::memmove(&time, stream.getU08ptr() + sizeof(Header) + rophead->datasize + offset_time, sizeof(time));
+    }  
+    
+    rophead->fmt.extract(plus, rqst, conf);
+    
+    return true;  
+}
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/embot/prot/eth/embot_prot_eth_rop.h
+++ b/embot/prot/eth/embot_prot_eth_rop.h
@@ -1,0 +1,252 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - brief
+//   it contains types of the eth protocol used inside icub: the rop 
+//
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_ROP_H_
+#define _EMBOT_PROT_ETH_ROP_H_
+
+#include "embot_core.h"
+#include "embot_core_utils.h"
+#include "embot_prot_eth.h"
+
+
+    // description
+    // a rop is formed by [header]-[<optional-payload>]
+    // the header is formed by 8 bytes: header = [ [ctlr]-[opc]-[datasize]-[id32] ] 
+    // the presence of the optional payload depends on header.ctrl and header.opc. 
+    // the optional payload, if present, is formed by the following bytes:    
+    // optional-payload = [optional-data]-[optiona-signature]-[optiona-time]
+    // its size is: header.datasize bytes (if data is present) + 4 bytes (if signature is present) + 8 bytes (if time is present)
+    
+    
+namespace embot { namespace prot {  namespace eth { namespace rop {
+      
+ 
+    // here are some types used inside a ROP, plus manipulating functions.
+    
+    
+    // some simple types
+    
+    enum class OPC : uint8_t { none = 0, ask = 1, say = 2, set = 3, sig = 4, any = 7 };    
+    using SIGN = std::uint32_t;
+    using TIME = embot::core::Time;
+    constexpr SIGN signatureNone = 0xffffffff;
+    static_assert(sizeof(TIME) == 8, "embot::prot::eth::rop::TIME must have 8 size");
+
+    enum class CONF : uint8_t { none = 0, nack = 1, ack = 2 };
+    enum class PLUS : uint8_t { none = 0, signature = 1, time = 2, signaturetime = 3 }; 
+    enum class RQST : uint8_t { none = 0, time = 1, confirmation = 2, timeconfirmation = 3 }; 
+
+      
+    // functions which manipulate the simple types
+    
+    constexpr PLUS getPLUS(bool hassignature, bool hastime) 
+    { 
+        constexpr PLUS tbl_bool2plus[2][2] = {{PLUS::none, PLUS::time}, {PLUS::signature, PLUS::signaturetime}};
+        return tbl_bool2plus[hassignature?1:0][hastime?1:0]; 
+    }
+    
+    constexpr RQST getRQST(bool reqconf, bool reqtime) 
+    { 
+        constexpr RQST tbl_bool2rqst[2][2] = {{RQST::none, RQST::time}, {RQST::confirmation, RQST::timeconfirmation}};
+        return tbl_bool2rqst[reqconf?1:0][reqtime?1:0]; 
+    }
+
+    constexpr bool hasSIGN(PLUS p)
+    {
+        constexpr bool tbl_plus2sign[4] = { false, true, false, true };
+        return tbl_plus2sign[embot::core::tointegral(p)];
+    }
+    
+    constexpr bool hasTIME(PLUS p)
+    {
+        constexpr bool tbl_plus2tim[4] = { false, false, true, true };
+        return tbl_plus2tim[embot::core::tointegral(p)];
+    }
+    
+    constexpr size_t capacityfor(PLUS p)
+    {
+        constexpr uint8_t tbl_size4plus[4] = {0, sizeof(SIGN), sizeof(embot::core::Time), sizeof(SIGN)+sizeof(embot::core::Time)};
+        return tbl_size4plus[embot::core::tointegral(p)];
+    }
+    
+    constexpr bool hasdata(OPC o, CONF c = CONF::none)
+    {   // if the confirmation is CONF::ack or CONF::nack then there is no data irrespectively of the opcode
+        constexpr bool tbl_opc2bool[8] = {false, false, true, true, true, false, false, true};
+        return (CONF::none == c) ? (tbl_opc2bool[embot::core::tointegral(o)]) : false;
+    }
+    
+    constexpr size_t normalisedsizeofdata(size_t s)
+    {   // size must always be multiple of 4
+        s = (s + 3)/4;
+        s = 4*s;
+        return s;
+    }
+
+    constexpr bool reqCONF(RQST r)
+    {
+        constexpr bool tbl_rqst2conf[4] = { false, false, true, true };
+        return tbl_rqst2conf[embot::core::tointegral(r)];
+    }
+
+    constexpr bool reqTIME(RQST r)
+    {
+        constexpr bool tbl_rqst2time[4] = { false, true, false, true };
+        return tbl_rqst2time[embot::core::tointegral(r)];
+    }
+    
+    
+    // aggregate types organised in struct. 
+    // they all have the relevant constexpr static size_t sizeofobject variable and a static assert because ... 
+    // 1. they must be that size
+    // 2. they must have that memory layout
+    
+    struct Header
+    {
+        struct Format
+        {   // spec document uses CTRL. we use Format, which better describes its role because CTRL is sic... a macro contained inside ttydefaults.h
+            constexpr static uint8_t versionzero = 0;
+            
+            // if i use "uint8_t confinfo : 2{0};" i have a warning: default member initializer for bit-field is a C++2a extension [-Wc++2a-extensions]
+            
+            // -> memory layout
+            uint8_t confinfo : 2;// {0};           // it is formed by bits 0 and 1. it contains confirmation info as in CONF
+            uint8_t plustime : 1;// {0};           // if 1 the ROP has the time field of 8 bytes
+            uint8_t plussign : 1;// {0};           // if 1 the ROP has the signature field of 4 bytes 
+            uint8_t rqsttime : 1;// {0};           // if 1 the ROP requests that a reply shall have the time field
+            uint8_t rqstconf : 1;// {0};           // if 1 the ROP requests that the received shall send confirmation */
+            uint8_t version  : 2;// {versionzero}; // it is formed by bits 7 and 6 of the first byte of the ROP. So far it must be versionzero      
+            // <- memory layout
+                       
+            Format() : version(versionzero) { set(PLUS::none); set(RQST::none); set(CONF::none); }
+            
+            constexpr Format(PLUS p, RQST r, CONF c) : confinfo(0), plustime(0), plussign(0), rqsttime(0), rqstconf(0), version(versionzero) { set(p); set(r); set(c); }
+                            
+            constexpr void set(PLUS p) { plustime = hasTIME(p); plussign = hasSIGN(p); }
+            constexpr void set(RQST r) { rqsttime = reqTIME(r); rqstconf = reqCONF(r); }
+            constexpr void set(CONF c) { confinfo = embot::core::tointegral(c); }
+                        
+            constexpr PLUS getPLUS() const { return embot::prot::eth::rop::getPLUS(plussign, plustime); }
+            constexpr RQST getRQST() const { return embot::prot::eth::rop::getRQST(rqstconf, rqsttime); }
+            constexpr CONF getCONF() const { return (3 == confinfo) ? CONF::none : static_cast<CONF>(confinfo); }             
+            
+            constexpr bool isPLUStime() const { return plustime; }
+            constexpr bool isPLUSsignature() const { return plussign; }           
+            constexpr bool hasRQSTtime() const { return rqsttime; }
+            constexpr bool hasRQSTconfirmation() const { return rqstconf; }
+            
+            constexpr void fill(PLUS p = PLUS::none, RQST r = RQST::none, CONF c = CONF::none) { set(p); set(r); set(c); }
+            constexpr void extract(PLUS& p, RQST& r, CONF &c) const { p = getPLUS(); r = getRQST(); c = getCONF(); } 
+            constexpr static size_t sizeofobject = 1;
+        }; static_assert(sizeof(Format) == Format::sizeofobject, "embot::prot::eth::rop::Header::Format has wrong size. it must be 1");
+                
+
+        // -> memory layout   
+        Format      fmt {};
+        OPC         opc {OPC::none};
+        uint16_t    datasize {0};
+        ID32        id32;
+        // <- memory layout
+        
+        
+        Header() = default;        
+        constexpr Header(const Format &f, OPC o, uint16_t s, ID32 i) : fmt(f), opc(o), datasize(s), id32(i) {}
+        
+        constexpr static size_t sizeofobject = 8;
+    }; static_assert(sizeof(Header) == Header::sizeofobject, "embot::prot::eth::rop::Header has wrong size. it must be 8");    
+    
+}}}} // namespace embot { namespace prot {  namespace eth { namespace rop {
+
+
+
+namespace embot { namespace prot {  namespace eth { namespace rop {
+    
+    // in here are the objects which we use to describe a rop or to represent the binary stream or ...
+    // they dont need to have an exact memory layout 
+    
+    struct Descriptor
+    {
+        OPC                     opcode {OPC::none};             
+        embot::prot::eth::ID32  id32 {embot::prot::eth::ID32none};  
+        embot::core::Data       value {nullptr, 0};             
+        SIGN                    signature {signatureNone};
+        embot::core::Time       time {embot::core::timeNone};
+        CONF                    conf {CONF::none};
+        PLUS                    plus {PLUS::none};
+        RQST                    rqst {RQST::none};
+
+        Descriptor() = default;
+        constexpr Descriptor(OPC o, embot::prot::eth::ID32 i, const embot::core::Data &v, SIGN s = signatureNone, embot::core::Time t = embot::core::timeNone,
+                             PLUS p = PLUS::none, RQST r = RQST::none, CONF c = CONF::none) :
+                             opcode(o), id32(i), value(v), signature(s), time(t), plus(p), rqst(r), conf(c) { }
+        constexpr bool isvalid() const { return ((embot::prot::eth::ID32none != id32) && (OPC::none != opcode) && (value.isvalid())); }
+
+        constexpr bool hassignature() const { return hasSIGN(plus); }
+        constexpr bool hastime() const { return hasTIME(plus); }
+
+        void reset() { 
+            opcode = OPC::none; id32 = embot::prot::eth::ID32none; value = {nullptr, 0}; signature = signatureNone; time = embot::core::timeNone; 
+            conf = CONF::none; plus = PLUS::none; rqst = RQST::none; 
+        }
+        
+        void fill(OPC o, embot::prot::eth::ID32 i, const embot::core::Data &v, SIGN s = signatureNone, embot::core::Time t = embot::core::timeNone,
+                  PLUS p = PLUS::none, RQST r = RQST::none, CONF c = CONF::none) {
+            opcode = o; id32 = i; value = v; signature = s; time = t; plus = p; rqst = r; conf = c;
+        }
+        
+        bool load(embot::core::Data &stream, uint16_t &consumed);
+    };
+    
+    using fpOnROP = bool (*)(const embot::prot::eth::IPv4 &ipv4, const embot::prot::eth::rop::Descriptor &rop);
+             
+
+    class Stream 
+    {
+    public:
+               
+        Stream(size_t capacity);  
+        ~Stream();
+
+        constexpr static size_t minimumsize = Header::sizeofobject; 
+    
+        constexpr static size_t capacityfor(OPC opc, size_t sizeofdata, PLUS plus = PLUS::none, CONF conf = CONF::none)
+        {
+            return Header::sizeofobject + (embot::prot::eth::rop::hasdata(opc, conf) ? embot::prot::eth::rop::normalisedsizeofdata(sizeofdata) : 0) + embot::prot::eth::rop::capacityfor(plus);
+        }
+        
+        constexpr static size_t capacityfor(const Descriptor &des)
+        {
+            return Header::sizeofobject + (embot::prot::eth::rop::hasdata(des.opcode, des.conf) ? embot::prot::eth::rop::normalisedsizeofdata(des.value.capacity) : 0) + embot::prot::eth::rop::capacityfor(des.plus);
+        }
+        
+        size_t getcapacity() const;
+
+        bool load(const Descriptor &des);
+        bool update(const embot::core::Data &data, const embot::prot::eth::rop::SIGN signature = embot::prot::eth::rop::signatureNone, const embot::core::Time time = embot::core::timeNone);
+        
+        // direct pointer
+        bool retrieve(uint8_t **data, size_t &size);      
+
+    private:    
+        struct Impl;
+        Impl *pImpl;
+    };  
+
+
+
+}}}} // namespace embot { namespace prot {  namespace eth { namespace rop {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/embot/prot/eth/embot_prot_eth_ropframe.cpp
+++ b/embot/prot/eth/embot_prot_eth_ropframe.cpp
@@ -1,0 +1,625 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_prot_eth_ropframe.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include <algorithm>
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace embot { namespace prot {  namespace eth { namespace ropframe {
+    
+struct coreImpl
+{    
+    uint8_t *theframe {nullptr};
+    size_t capacityoftheframe {0};
+    size_t sizeoftheframe {0};
+
+    Header *ref2header {nullptr};
+    uint8_t *ref2body {nullptr};
+    uint8_t *ref2bodyend {nullptr};
+    Footer *ref2footer {nullptr};    
+    
+    embot::prot::eth::rop::Stream *_ropstream2 {nullptr};
+    
+    constexpr static uint16_t minimumsize = Header::sizeofobject + Footer::sizeofobject;
+
+    coreImpl()
+    {
+    }   
+
+    ~coreImpl()
+    {
+    }
+
+    uint16_t availablebytes() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }
+        int a = capacityoftheframe - minimumsize - ref2header->sizeofbody;
+        return (a>0) ? a : 0;
+    }
+    
+    bool load(const embot::core::Data &frame, embot::prot::eth::rop::Stream *rstream)
+    {
+        _ropstream2 = rstream;
+       return load(frame, true);        
+    }
+
+
+    bool load(const embot::core::Data &frame, bool andformat = true)
+    {
+        if((!frame.isvalid()) || (frame.capacity < minimumsize))
+        {
+            return false;
+        }
+       
+        theframe = reinterpret_cast<uint8_t*>(frame.pointer);
+        capacityoftheframe = frame.capacity;
+        ref2header = reinterpret_cast<Header*>(theframe);
+        sizeoftheframe = minimumsize + ref2header->sizeofbody;
+        ref2body = theframe + Header::sizeofobject;
+
+        if(false == andformat)
+        {
+            if((minimumsize + ref2header->sizeofbody) > frame.capacity)
+            {
+                unload();
+                return false;
+            }
+
+            ref2bodyend = ref2body + ref2header->sizeofbody;
+            ref2footer = reinterpret_cast<Footer*>(ref2bodyend);
+            if(!ref2footer->isvalid())
+            {
+                unload();
+                return true;
+            }
+        }
+        else
+        {
+            // ok, now i format the memory of the roframe
+            format();
+        }
+                                    
+        return true;
+    }
+
+    bool unload()
+    {
+        theframe = nullptr;
+        capacityoftheframe = 0;
+        sizeoftheframe = 0;
+        ref2header = nullptr;
+        ref2body = nullptr;
+        ref2bodyend = nullptr;
+        ref2footer = nullptr;
+        
+        _ropstream2 = nullptr;
+
+        return true;
+    }
+
+    bool format()
+    {
+        if(nullptr == ref2header)
+        {
+            return false;
+        }
+
+        ref2header->reset();
+        sizeoftheframe = minimumsize;
+        ref2bodyend = ref2body + ref2header->sizeofbody;
+        ref2footer = reinterpret_cast<Footer*>(ref2bodyend);
+        ref2footer->refresh();
+        
+        return true;
+    }
+
+    bool isvalid() const
+    {
+        if((nullptr == ref2header) || (nullptr == ref2footer))
+        {
+            return false;
+        }
+
+        // else i must have a well formatted ropframe. i check that        
+        return ref2header->isvalid() && ref2footer->isvalid();
+    }
+
+
+    uint16_t getSize() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }  
+        return minimumsize + ref2header->sizeofbody;       
+    }
+
+    uint16_t getNumberOfROPs() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }  
+        return ref2header->numberofrops;     
+    }
+
+    uint16_t getSizeOfROPs() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }  
+        return ref2header->sizeofbody;   
+    }
+
+
+    bool pushback(const embot::core::Data &ropstream, uint16_t &availablespace)
+    {
+        if(nullptr == ref2header)
+        {
+            availablespace = 0;
+            return false;
+        } 
+
+        if(!ropstream.isvalid())
+        {
+            availablespace = availablebytes();
+            return false;
+        }
+
+        // can i add extra ropstream.capacity bytes?
+        if((ropstream.capacity + ref2header->sizeofbody + minimumsize) > capacityoftheframe)
+        {
+            availablespace = availablebytes();
+            return false;
+        }
+
+        // yes, i can
+ 
+        std::memmove(ref2bodyend, ropstream.pointer, ropstream.capacity);        
+        ref2header->add_rop(ropstream.capacity);
+
+        ref2bodyend = ref2body + ref2header->sizeofbody;
+        ref2footer = reinterpret_cast<Footer*>(ref2bodyend);
+        ref2footer->refresh();
+
+        return true;
+    }
+
+    bool pushback(const embot::prot::eth::rop::Descriptor &ropdes, uint16_t &availablespace)
+    {
+        if((nullptr == ref2header) || (nullptr == _ropstream2))
+        {
+            availablespace = 0;
+            return false;
+        } 
+        
+        size_t cap = _ropstream2->capacityfor(ropdes);
+        // can the _ropstream2 host it?
+        if(cap > _ropstream2->getcapacity())
+        {
+            return false;
+        }
+        
+        // can this object host it?
+        if((cap + ref2header->sizeofbody + minimumsize) > capacityoftheframe)
+        {
+            availablespace = availablebytes();
+            return false;
+        }
+               
+        if(false == _ropstream2->load(ropdes))
+        {
+            availablespace = availablebytes();
+            return false;            
+        }
+        
+        uint8_t *pointer = nullptr;
+        size_t size = 0;
+        _ropstream2->retrieve(&pointer, size);
+
+        std::memmove(ref2bodyend, pointer, size);        
+        ref2header->add_rop(size);
+
+        ref2bodyend = ref2body + ref2header->sizeofbody;
+        ref2footer = reinterpret_cast<Footer*>(ref2bodyend);
+        ref2footer->refresh();
+
+        return true;
+    }
+
+    bool setTime(embot::core::Time t)
+    {
+        if(nullptr == ref2header)
+        {
+            return false;
+        }
+        ref2header->set_age(t); 
+        return true;
+    }
+    
+    embot::core::Time getTime() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }
+        return ref2header->get_age(); 
+    }
+
+    bool setSequenceNumber(uint64_t s)
+    {
+        if(nullptr == ref2header)
+        {
+            return false;
+        }
+        ref2header->set_seq(s); 
+        return true;
+    }
+
+    bool incSequenceNumber()
+    {
+        if(nullptr == ref2header)
+        {
+            return false;
+        }
+        ref2header->inc_seq(); 
+        return true;
+    }
+
+    uint64_t getSequenceNumber() const
+    {
+        if(nullptr == ref2header)
+        {
+            return 0;
+        }
+        return ref2header->get_seq();         
+    }
+
+
+    bool parse(const embot::prot::eth::IPv4 &ipv4, embot::prot::eth::rop::fpOnROP onrop, uint16_t &numberofprocessed)
+    {
+        numberofprocessed = 0;
+
+        if(nullptr == onrop)
+        {
+            return false;
+        }
+
+        if(nullptr == ref2header)
+        {
+            return false;
+        }
+
+        size_t nbytes = 0;
+        embot::prot::eth::rop::Descriptor des{};
+        uint8_t *body = ref2body;
+        uint16_t avail = ref2header->sizeofbody; 
+        for(auto i=0; i<ref2header->numberofrops; i++)
+        {
+            uint16_t consumed = 0;
+            embot::core::Data stream(body, avail);
+            if(false == des.load(stream, consumed))
+            {
+                break;
+            }
+            
+            numberofprocessed += consumed;
+            body += consumed;            
+            onrop(ipv4, des);
+        }
+
+        return true;
+    }
+
+    bool get(embot::core::Data& frame, uint16_t &capacity) const
+    {
+        frame.capacity = getSize();
+        frame.pointer = theframe;
+        capacity = capacityoftheframe;
+        return true;
+    }
+
+};
+
+
+}}}} // namespace embot { namespace prot {  namespace eth { namespace ropframe {
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --- ropframe which only decodes
+
+struct embot::prot::eth::ropframe::Parser::Impl : public embot::prot::eth::ropframe::coreImpl
+{ 
+};
+
+embot::prot::eth::ropframe::Parser::Parser()
+: pImpl(new Impl())
+{ 
+}
+
+embot::prot::eth::ropframe::Parser::~Parser()
+{   
+    delete pImpl;
+}
+
+bool embot::prot::eth::ropframe::Parser::load(const embot::core::Data &frame)
+{
+    return pImpl->load(frame, false);
+}
+
+bool embot::prot::eth::ropframe::Parser::unload()
+{
+    return pImpl->unload();
+}
+
+bool embot::prot::eth::ropframe::Parser::parse(const embot::prot::eth::IPv4 &ipv4, embot::prot::eth::rop::fpOnROP onrop, uint16_t &numberofprocessed)
+{
+    return pImpl->parse(ipv4, onrop, numberofprocessed);
+}
+
+uint64_t  embot::prot::eth::ropframe::Parser::getSequenceNumber() const
+{
+    return pImpl->getSequenceNumber();
+}
+
+bool embot::prot::eth::ropframe::Parser::isvalid() const
+{
+    return pImpl->isvalid();
+}
+
+uint16_t embot::prot::eth::ropframe::Parser::getNumberOfROPs() const
+{
+    return pImpl->getNumberOfROPs();
+}
+
+// --- ropframe which only encodes
+
+struct embot::prot::eth::ropframe::Former::Impl : public embot::prot::eth::ropframe::coreImpl
+{  
+};
+
+embot::prot::eth::ropframe::Former::Former()
+: pImpl(new Impl())
+{ 
+}
+
+embot::prot::eth::ropframe::Former::~Former()
+{   
+    delete pImpl;
+}
+
+bool embot::prot::eth::ropframe::Former::load(const embot::core::Data &frame)
+{
+    return pImpl->load(frame, true);
+}
+
+bool embot::prot::eth::ropframe::Former::load(const embot::core::Data &frame, embot::prot::eth::rop::Stream *rstream)
+{
+    return pImpl->load(frame, rstream);
+}
+
+bool embot::prot::eth::ropframe::Former::unload()
+{
+    return pImpl->unload();
+}
+
+bool embot::prot::eth::ropframe::Former::format()
+{
+    return pImpl->format();
+}
+
+bool embot::prot::eth::ropframe::Former::set(embot::core::Time tim, uint64_t seq)
+{
+    return pImpl->setSequenceNumber(seq) && pImpl->setTime(tim);
+}
+
+
+bool embot::prot::eth::ropframe::Former::get(embot::core::Data& frame) const
+{
+    uint16_t capacity = 0;
+    return pImpl->get(frame, capacity);
+}
+
+uint16_t embot::prot::eth::ropframe::Former::getNumberOfROPs() const
+{
+    return pImpl->getNumberOfROPs();
+}
+
+bool embot::prot::eth::ropframe::Former::pushback(const embot::core::Data &ropstream, uint16_t &availablespace)
+{
+    return pImpl->pushback(ropstream, availablespace);
+}
+
+bool embot::prot::eth::ropframe::Former::pushback(const embot::prot::eth::rop::Descriptor &ropdes, uint16_t &availablespace)
+{
+    return pImpl->pushback(ropdes, availablespace);
+}
+
+
+// --- ropframe which does everything
+
+#if 0   
+namespace embot { namespace prot {  namespace eth { namespace ropframe {  
+
+    // 3. ROPframe: it can be uses in parser mode or former mode.
+
+    // the ROPframe can be uses in two modes: in encode mode or in decode mode
+    // 1.   encode mode
+    //      the object is created as an empty shell. 
+    //      we give to it storage with load() using andformat = true.
+    //      we add as many ropstreams / rops we need w/ calls to pushback() 
+    //      when it is time to transmit the ropframe, we retrieve it w/ get() which copies into external ram
+    //      then we format the internal data w/ format() so that we can put new rops inside
+    // 2.   decode mode
+    //      the object is created as an empty shell.
+    //      when a udp packet is received, we load it with load({udp.data, udp.size}, andformat = false)
+    //      we get info using the const getters (isvalid, getsize, etc.)
+    //      if valid, and if there are rops inside: we parse with parse() where each rop is processed by
+    //      function oprop(); 
+    
+
+    class ROPframe
+    {
+
+    public:
+
+        constexpr static uint16_t minimumsize = Header::sizeofobject + Footer::sizeofobject;
+
+        ROPframe(); // empty shell
+        ~ROPframe();
+
+        bool load(const embot::core::Data &frame, bool andformat = true); // it loads a received udp packet 
+        bool unload();
+
+        bool format(); // it formats the object to have a legal header-footer and zero rops. 
+
+        // const getters
+        bool isvalid() const; // tells if data is well formatted (w/ zero or more rops)    
+        uint16_t getSize() const;
+        uint16_t getNumberOfROPs() const;    
+        uint16_t getSizeOfROPs() const;
+        embot::core::Time getTime() const;
+        uint64_t getSequenceNumber() const;
+    
+        bool get(embot::core::Data& frame, uint16_t &capacity) const; // copies the whole frame. e.g., for its tx
+    
+        // basic setters: time + sequencenumber
+        bool setTime(embot::core::Time t);
+        bool setSequenceNumber(uint64_t s);
+        bool incSequenceNumber();
+        
+        // pushback a ropstream to the frame
+        bool pushback(const embot::core::Data &ropstream, uint16_t &availablespace);
+
+        // add a ropdescriptor to the frame
+//        bool append(const embot::prot::eth::rop::Descriptor &ropdescr, uint16_t &availablespace);
+
+        // internally extracts all the rop descriptors in the body and calls onrop() for each of them 
+        bool parse(const embot::prot::eth::IPv4 &ipv4, embot::prot::eth::rop::fpOnROP onrop, uint16_t &numberofprocessed);
+
+
+//        // i must now extract one rop at a time. i dont want to give a rop number to extract because it would be heavy to compute their positions beforehands
+//        // hence, i use extractstart() and extract()
+//        bool extractstart(uint16_t &remainingrops, uint16_t &remainingbytes);
+
+//        // it return true if extraction was ok. for the last rop it returns true and remainingrops = 0 and remainingbytes = 0.
+//        // it returns false if it is called when no more rops or data are extacted OR IF the Descriptor is not valid.
+//        bool extract(embot::prot::eth::rop::Descriptor &ropdescr, uint16_t &remainingrops, uint16_t &remainingbytes); // retrieve the next ropdes
+
+//        //bool append(const embot::prot::eth::rop::Descriptor &ropdescr, uint16_t &availablespace);   // append a single rop
+
+//        // bool append(const ROPframe &rhv, uint16_t &availablespace); // append all the rops inside rhv
+
+
+    private:    
+        struct Impl;
+        Impl *pImpl;
+    };
+
+}}}} // namespace embot { namespace prot {  namespace eth { namespace ropframe {  
+#endif
+
+#if 0
+struct embot::prot::eth::ropframe::ROPframe::Impl : public embot::prot::eth::ropframe::coreImpl
+{
+};
+
+
+embot::prot::eth::ropframe::ROPframe::ROPframe()
+: pImpl(new Impl())
+{ 
+
+}
+
+embot::prot::eth::ropframe::ROPframe::~ROPframe()
+{   
+    delete pImpl;
+}
+
+bool embot::prot::eth::ropframe::ROPframe::load(const embot::core::Data &frame, bool andformat)
+{
+    return pImpl->load(frame, andformat);
+}
+
+bool embot::prot::eth::ropframe::ROPframe::unload()
+{
+    return pImpl->unload();
+}
+
+
+bool embot::prot::eth::ropframe::ROPframe::format()
+{
+    return pImpl->format();
+}
+
+bool embot::prot::eth::ropframe::ROPframe::parse(const embot::prot::eth::IPv4 &ipv4, embot::prot::eth::rop::fpOnROP onrop, uint16_t &numberofprocessed)
+{
+    return pImpl->parse(ipv4, onrop, numberofprocessed);
+}
+
+uint64_t  embot::prot::eth::ropframe::ROPframe::getSequenceNumber() const
+{
+    return pImpl->getSequenceNumber();
+}
+
+bool  embot::prot::eth::ropframe::ROPframe::setSequenceNumber(uint64_t s)
+{
+    return pImpl->setSequenceNumber(s);
+}
+
+bool embot::prot::eth::ropframe::ROPframe::isvalid() const
+{
+    return pImpl->isvalid();
+}
+
+bool embot::prot::eth::ropframe::ROPframe::get(embot::core::Data& frame, uint16_t &capacity) const
+{
+    return pImpl->get(frame, capacity);
+}
+
+
+bool embot::prot::eth::ropframe::ROPframe::setTime(embot::core::Time t)
+{
+    return pImpl->setTime(t);
+}
+
+uint16_t embot::prot::eth::ropframe::ROPframe::getNumberOfROPs() const
+{
+    return pImpl->getNumberOfROPs();
+}
+
+bool embot::prot::eth::ropframe::ROPframe::pushback(const embot::core::Data &ropstream, uint16_t &availablespace)
+{
+    return pImpl->pushback(ropstream, availablespace);
+}
+#endif
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/embot/prot/eth/embot_prot_eth_ropframe.h
+++ b/embot/prot/eth/embot_prot_eth_ropframe.h
@@ -1,0 +1,162 @@
+
+/*
+ * Copyright (C) 2019 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - brief
+//   it contains types of the eth protocol used inside icub: the rop 
+//
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_PROT_ETH_ROPFRAME_H_
+#define _EMBOT_PROT_ETH_ROPFRAME_H_
+
+#include "embot_core.h"
+#include "embot_core_utils.h"
+#include "embot_prot_eth_rop.h"
+
+
+    // description
+    // a ropframe is formed by [header]-[<optional-body>]-[footer]
+    // the header is formed by 24 bytes: header = [STARTCODE]-[sizeofbody]-[numberofrops]-[sequencenumber]-[ageofframe] 
+    // the presence of the optional body depends on header.sizeofbody.
+    // the body contains a number of rops specified by header.numerofrops aligned one after another
+    // in stream format.
+    // the footer is just a marker at the end of the ropframe
+    
+
+namespace embot { namespace prot {  namespace eth { namespace ropframe {
+
+    
+    // aggregate types organised in struct. 
+    // they all have the relevant constexpr static size_t sizeofobject variable and a static assert because ... 
+    // 1. they must be that size
+    // 2. they must have that memory layout
+    
+    struct Header
+    {
+        constexpr static uint32_t STARTCODE = 0x12345678; 
+
+        // -> memory layout
+        uint32_t startcode {STARTCODE};
+        uint16_t sizeofbody {0};
+        uint16_t numberofrops {0};
+        uint64_t sequencenumber {0};
+        embot::core::Time ageofframe {0};
+        // <- memory layout
+        
+        Header() = default;
+            
+        void reset() { startcode = STARTCODE; sizeofbody = 0; numberofrops = 0; sequencenumber = 0; ageofframe = 0; }
+        void add_rop(uint16_t ropstreamsize) { numberofrops++; sizeofbody += ropstreamsize; }
+        void set_age(embot::core::Time a) { ageofframe = a; }
+        embot::core::Time get_age() const { return ageofframe; }
+        void set_seq(uint64_t s) { sequencenumber = s; }
+        uint64_t get_seq() const { return sequencenumber; }
+        void inc_seq() { sequencenumber++; }
+        
+        constexpr bool isvalid() const { return STARTCODE == startcode; }
+        
+        constexpr static size_t sizeofobject = 24;
+    }; static_assert(sizeof(Header) == Header::sizeofobject, "embot::prot::eth::ropframe::Header has wrong size. it must be 24");
+    
+    
+    struct Footer
+    {
+        constexpr static uint32_t STOPCODE = 0x87654321; 
+        
+        // -> memory layout
+        uint32_t stopcode {STOPCODE};
+        // <- memory layout
+        
+        Footer() = default;
+        void refresh() { stopcode = STOPCODE; }
+        bool isvalid() const { return STOPCODE == stopcode; }
+               
+        constexpr static size_t sizeofobject = 4;
+    }; static_assert(sizeof(Footer) == Footer::sizeofobject, "embot::prot::eth::rop::Footer has wrong size. it must be 4");
+     
+    
+}}}} // namespace embot { namespace prot {  namespace eth { namespace ropframe {
+
+
+
+namespace embot { namespace prot {  namespace eth { namespace ropframe {   
+ 
+    // in here are the objects which we use to describe a ropframe or to represent the binary stream or ...
+    // they dont need to have an exact memory layout. they are:    
+    // 1. Former: it can be used in former mode only. it uses an empty ropframe and adds to it the required ROPs
+    // 2. Parser: it can be used in parser mode only. it accepts a full ropframe and parses the ROPs inside
+
+    
+   
+    // ropframe::Former - description:
+    // a. it is created as an empty shell to which we can load() external storage or unload() it.
+    // b. we can format() the storage to be a valid ropframe w/ zero rops
+    // c. we can pushback() to it a ropstream or a rop::Descriptor
+    // d. we can set time and sequance number
+    // e. we retrieve the frame
+    // todo? add: get(tim, set) isvalid()
+    
+    class Former
+    {
+    public:
+            
+        Former();
+        ~Former();
+
+        bool load(const embot::core::Data &storage);
+        bool load(const embot::core::Data &storage, embot::prot::eth::rop::Stream *rstream);
+        bool unload();   
+        bool pushback(const embot::core::Data &ropstream, uint16_t &availablespace);             
+        bool pushback(const embot::prot::eth::rop::Descriptor &ropdes, uint16_t &availablespace);
+        bool set(embot::core::Time tim, uint64_t seq);    
+        uint16_t getNumberOfROPs() const;    
+        bool get(embot::core::Data& ropframe) const;    
+        bool format();
+    
+    private:    
+        struct Impl;
+        Impl *pImpl;         
+    };
+    
+    
+    // ropframe::Parser - description:
+    // a. it is created as an empty shell to which we can load() a received ropframe and later unload() it.
+    // b. we can check: if it isvalid(), its size, number of rops etc. 
+    // c. we can parse all the ROPs inside by calling a user-defined callback
+    
+    class Parser
+    {
+    public:
+            
+        Parser();
+        ~Parser();
+
+        bool load(const embot::core::Data &ropframe);
+        bool unload();
+        // const getters
+        bool isvalid() const;         
+        uint16_t getSize() const;
+        uint16_t getNumberOfROPs() const;
+        uint16_t sizeofROPS() const;
+        embot::core::Time getTime() const;
+        uint64_t getSequenceNumber() const;           
+        bool parse(const embot::prot::eth::IPv4 &ipv4, embot::prot::eth::rop::fpOnROP onrop, uint16_t &numberofprocessed);        
+                       
+    private:    
+        struct Impl;
+        Impl *pImpl;     
+    };
+    
+
+}}}} // namespace embot { namespace prot {  namespace eth { namespace rop {
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/eth/embobj/core/core/EOpacket.c
+++ b/eth/embobj/core/core/EOpacket.c
@@ -381,6 +381,16 @@ extern eOresult_t eo_packet_Capacity_Get(EOpacket *p, uint16_t *capacity)
     return(eores_OK);
 }
 
+extern uint16_t eo_packet_Size_Get(EOpacket *p)
+{
+    if(NULL == p) 
+    {
+        return(0);
+    }
+
+    return p->size;    
+}
+
 extern uint16_t eo_packet_Payload_Pad(EOpacket *p, uint16_t finalsize, uint8_t val)
 {
     if(NULL == p) 

--- a/eth/embobj/core/core/EOpacket.h
+++ b/eth/embobj/core/core/EOpacket.h
@@ -215,6 +215,7 @@ extern eOresult_t eo_packet_Full_Clear(EOpacket *p, uint8_t val);
  **/
 extern eOresult_t eo_packet_Capacity_Get(EOpacket *p, uint16_t *capacity);
 
+extern uint16_t eo_packet_Size_Get(EOpacket *p);
 
 /** @fn         extern uint16_t eo_packet_Payload_Pad(EOpacket *p, uint16_t finalsize, uint8_t val)
     @brief      Append the value @e val to end of packet so that its final size becomes @e finalsize

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -320,7 +320,8 @@ const eoerror_valuestring_t eoerror_valuestrings_ETHMON[] =
     {eoerror_value_ETHMON_link_goes_down,   "ETH monitor: link goes down in port specified by par16 (0 = ETH input (P2/P13/J4) , 1 = ETH output (P3/P12/J5) , 2 = internal).  Application state is most significant nibble of par64: 0 -> N/A, 1 -> idle, 3 -> running."},
     {eoerror_value_ETHMON_error_rxcrc,      "ETH monitor: detected RX CRC error in port specified by par16 (0 = ETH input (P2/P13/J4) , 1 = ETH output (P3/P12/J5) , 2 = internal).  Application state is in most significant nibble of par64: 0 -> N/A, 1 -> idle, 3 -> running. Number of errors in par64&0xffffffff"},
     {eoerror_value_ETHMON_txseqnumbermissing, "ETH monitor: the board low level ETH detected a missing ropframe w/ expected sequence number in par64 and number of detected in par16"},
-    {eoerror_value_ETHMON_juststarted,      "ETH monitor: just started."}
+    {eoerror_value_ETHMON_juststarted,      "ETH monitor: just started."},
+    {eoerror_value_ETHMON_justverified, "ETH monitor: just verified, no news"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_ETHMON, eoerror_value_ETHMON_numberof*sizeof(const eoerror_valuestring_t)) 
 
 const eoerror_valuestring_t eoerror_valuestrings_IS[] =

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -379,10 +379,11 @@ typedef enum
     eoerror_value_ETHMON_link_goes_down                 = 1,
     eoerror_value_ETHMON_error_rxcrc                    = 2,
     eoerror_value_ETHMON_txseqnumbermissing             = 3,
-    eoerror_value_ETHMON_juststarted                    = 4
+    eoerror_value_ETHMON_juststarted                    = 4,
+    eoerror_value_ETHMON_justverified                   = 5
 } eOerror_value_ETHMON_t;
 
-enum { eoerror_value_ETHMON_numberof = 5 };
+enum { eoerror_value_ETHMON_numberof = 6 };
 
 
 /** @typedef    typedef enum eOerror_value_IS_t


### PR DESCRIPTION
Added some embot objects which are required to be shared by both ETH boards and code running on icub-head (`icub-main` + `diagnostic-daemon`) 

Also, did small improvements to embobj's + and EoError.

They belong to namespaces `embot::prot::eth` + ` embot::prot::eth::diagnostic` and they:
- depend only from embot::core
 - allow cross-platform generic handling of ETH protocol communication (rop, ropframe etc.)
 - allow cross-platform handling of diagnostic messages equal to those defined by
  {endpoint = management, entity = info, tag = eoprot_tag_mn_info_status}  and {endpoint = management, entity = info, tag = eoprot_tag_mn_info_status_basic}


Hence, they allow the use of a eth protocol tx/rx of diagnostic using an implementation much smaller and flexible than that inside the embobj library.

This PR compiles and work with robotology's icub-firmware and icub-main (devel branches).

