### PR TITLE
feat/towardslibrary

### DIFF
--- a/eth/embobj/core/core/EOaction.h
+++ b/eth/embobj/core/core/EOaction.h
@@ -72,7 +72,7 @@ typedef enum
 typedef struct EOaction_hid EOaction;
 
 
-enum { EOaction_sizeof = 16 };
+enum { EOaction_sizeof = 32 };
 typedef uint8_t EOaction_strg[EOaction_sizeof];
 
     

--- a/eth/embobj/core/core/EOaction_hid.h
+++ b/eth/embobj/core/core/EOaction_hid.h
@@ -77,10 +77,8 @@ struct EOaction_hid
         } cbk;
 
     } data;
-}; EO_VERIFYproposition(sss, (EOaction_sizeof >= sizeof(EOaction)))  
-//EO_VERIFYsizeof(EOaction, EOaction_sizeof)  
+}; EO_VERIFYproposition(sss, (EOaction_sizeof >= sizeof(EOaction))) 
 
-EO_VERIFYproposition(sss, (EOaction_sizeof >= sizeof(EOaction)))
  
 #define EOACTION_DUMMY      { eo_actypeNONE, {0} }
 

--- a/eth/embobj/core/exec/yarp/EOYmutex.c
+++ b/eth/embobj/core/exec/yarp/EOYmutex.c
@@ -29,8 +29,14 @@
 #include "EOVmutex_hid.h"
 
 
+#if defined(EMBOBJ_dontuseexternalincludes)
+extern void* ace_mutex_new(void);
+extern int8_t ace_mutex_take(void* m, uint32_t tout_usec);
+extern int8_t ace_mutex_release(void* m);
+extern void ace_mutex_delete(void* m);
+#else
 #include <FeatureInterface.h>   // to see the acemutex_* functions
-
+#endif
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern public interface

--- a/eth/embobj/core/exec/yarp/EOYtheSystem.c
+++ b/eth/embobj/core/exec/yarp/EOYtheSystem.c
@@ -31,7 +31,15 @@
 #include "math.h"
 
 #if     defined(EOY_SYS_USE_FEATURE_INTERFACE)
+
+#if defined(EMBOBJ_dontuseexternalincludes)
+extern double feat_yarp_time_now(void);
+#else
 #include "FeatureInterface.h"
+#endif
+
+#else
+
 #endif
 
 
@@ -164,7 +172,7 @@ extern EOYtheSystem * eoy_sys_Initialise(const eOysystem_cfg_t *syscfg,
 
     // initialise y-environment
     
-#if     defined(EOY_SYS_USE_FEATURE_INTERFACE) 
+#if     defined(EOY_SYS_USE_FEATURE_INTERFACE)
     s_eoy_system.start = feat_yarp_time_now();
 #else
 
@@ -246,8 +254,10 @@ static eOabstime_t s_eoy_sys_abstime_get(void)
 #if     defined(EOY_SYS_USE_FEATURE_INTERFACE)
 
     double delta = feat_yarp_time_now() - s_eoy_system.start;
+
     delta *= (1e6);
     time = (eOabstime_t)floor(delta);
+
 
 #else//defined(EOY_SYS_USE_FEATURE_INTERFACE)
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -42,7 +42,7 @@ extern "C" {
 // - external dependencies --------------------------------------------------------------------------------------------
 
 #include "EoCommon.h"
-#include "iCubCanProto_types.h"    
+#include "iCubCanProto_types.h"
 
 
 // - public #define  --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
preparation for compilation of the emboj as a library:
-removes dependencies from other include files. (if defined macro EMBOBJ_dontuseexternalincludes which is normally undefined so that everything for now stays unchanged)
- increased EOaction_sizeof to be = 32 to fix error in 64-bits architectures.

these changes give no side effect either on icub-main and on icub-firmware.
