### PR TITLE
feat/timesynch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.16.0)
+        VERSION 1.16.100)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -160,7 +160,7 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_transceiver_rxinvalidframe_error, "SYS: the board has detected an invalid ropframe in reception."},
     {eoerror_value_SYS_canservices_boards_lostcontact, "SYS: a service has detected that some CAN boards are not broacasting anymore. In par16 the type of boards, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
     {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered some CAN boards that were not broacasting anymore. In par16 the type of boards)"},
-    {eoerror_value_SYS_applicationstarting, "SYS: the application is starting after a reboot)"}
+    {eoerror_value_SYS_bootstrapping, "SYS: the board is bootstrapping"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -159,7 +159,8 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_canservices_board_notfound, "SYS: the board on the specified CAN bus / adr was not found during the discovery phase. In par16 there is the board type"},
     {eoerror_value_SYS_transceiver_rxinvalidframe_error, "SYS: the board has detected an invalid ropframe in reception."},
     {eoerror_value_SYS_canservices_boards_lostcontact, "SYS: a service has detected that some CAN boards are not broacasting anymore. In par16 the type of boards, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
-    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered some CAN boards that were not broacasting anymore. In par16 the type of boards)"}
+    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered some CAN boards that were not broacasting anymore. In par16 the type of boards)"},
+    {eoerror_value_SYS_applicationstarting, "SYS: the application is starting after a reboot)"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -172,10 +172,11 @@ typedef enum
     eoerror_value_SYS_canservices_board_notfound            = 55,
     eoerror_value_SYS_transceiver_rxinvalidframe_error      = 56,
     eoerror_value_SYS_canservices_boards_lostcontact        = 57,
-    eoerror_value_SYS_canservices_boards_retrievedcontact   = 58
+    eoerror_value_SYS_canservices_boards_retrievedcontact   = 58,
+    eoerror_value_SYS_applicationstarting                   = 59
 } eOerror_value_SYS_t;
 
-enum { eoerror_value_SYS_numberof = 59 };
+enum { eoerror_value_SYS_numberof = 60 };
 
 
 /** @typedef    typedef enum eOerror_value_HW_t

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -173,7 +173,7 @@ typedef enum
     eoerror_value_SYS_transceiver_rxinvalidframe_error      = 56,
     eoerror_value_SYS_canservices_boards_lostcontact        = 57,
     eoerror_value_SYS_canservices_boards_retrievedcontact   = 58,
-    eoerror_value_SYS_applicationstarting                   = 59
+    eoerror_value_SYS_bootstrapping                         = 59
 } eOerror_value_SYS_t;
 
 enum { eoerror_value_SYS_numberof = 60 };

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -308,18 +308,19 @@ typedef struct                      // size is 1+7 = 8 bytes
 {
     eOenum08_t                      go2state;       /**< use eOmn_appl_state_t */
     uint8_t                         filler07[7];
-} eOmn_appl_cmmnds_t;               //EO_VERIFYsizeof(eOmn_appl_cmmnds_t, 8)
+    eOabstime_t                     timeset;
+} eOmn_appl_cmmnds_t;               EO_VERIFYsizeof(eOmn_appl_cmmnds_t, 16)
 
 
 /** @typedef    typedef struct eOmn_appl_t;
     @brief      used to represent the application with config, status, commands
  **/
-typedef struct                      // size is 8+32+8 = 48 bytes
+typedef struct                      // size is 16+32+16 = 48 bytes
 {
     eOmn_appl_config_t              config;
     eOmn_appl_status_t              status;
     eOmn_appl_cmmnds_t              cmmnds;
-} eOmn_appl_t;                      //EO_VERIFYsizeof(eOmn_appl_t, 48)
+} eOmn_appl_t;                      EO_VERIFYsizeof(eOmn_appl_t, 64)
 
 
 // -- the definition of info entity

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 15 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 16 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };
@@ -119,10 +119,11 @@ typedef enum
     eoprot_tag_mn_appl_config                                       = 1,
     eoprot_tag_mn_appl_config_txratedivider                         = 2,
     eoprot_tag_mn_appl_status                                       = 3,
-    eoprot_tag_mn_appl_cmmnds_go2state                              = 4
+    eoprot_tag_mn_appl_cmmnds_go2state                              = 4,
+    eoprot_tag_mn_appl_cmmnds_timeset                               = 5
 } eOprot_tag_mn_appl_t;
 
-enum { eoprot_tags_mn_appl_numberof = 5 };  // it MUST be equal to the number of tags. 
+enum { eoprot_tags_mn_appl_numberof = 6 };  // it MUST be equal to the number of tags. 
 
 
 /** @typedef    typedef enum eOprot_rwm_mn_appl_t
@@ -135,10 +136,11 @@ typedef enum
     eoprot_rwm_mn_appl_config                                       = eo_nv_rwmode_RW,
     eoprot_rwm_mn_appl_config_txratedivider                         = eo_nv_rwmode_RW,
     eoprot_rwm_mn_appl_status                                       = eo_nv_rwmode_RO,
-    eoprot_rwm_mn_appl_cmmnds_go2state                              = eo_nv_rwmode_RW
+    eoprot_rwm_mn_appl_cmmnds_go2state                              = eo_nv_rwmode_RW,
+    eoprot_rwm_mn_appl_cmmnds_timeset                               = eo_nv_rwmode_RW
 } eOprot_rwm_mn_appl_t; 
 
-enum { eoprot_rwms_mn_appl_numberof = 5 };  // it MUST be equal to the number of rw modes. 
+enum { eoprot_rwms_mn_appl_numberof = 6 };  // it MUST be equal to the number of rw modes. 
 
 
 // - entity info
@@ -271,6 +273,8 @@ extern void eoprot_fun_UPDT_mn_appl_status(const EOnv* nv, const eOropdescriptor
 extern void eoprot_fun_INIT_mn_appl_cmmnds_go2state(const EOnv* nv);
 extern void eoprot_fun_UPDT_mn_appl_cmmnds_go2state(const EOnv* nv, const eOropdescriptor_t* rd);
 
+extern void eoprot_fun_INIT_mn_appl_cmmnds_timeset(const EOnv* nv);
+extern void eoprot_fun_UPDT_mn_appl_cmmnds_timeset(const EOnv* nv, const eOropdescriptor_t* rd);
 
 // - info
 

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMN_fun.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMN_fun.c
@@ -207,6 +207,12 @@ EO_weak extern void eoprot_fun_INIT_mn_appl_cmmnds_go2state(const EOnv* nv) {}
 EO_weak extern void eoprot_fun_UPDT_mn_appl_cmmnds_go2state(const EOnv* nv, const eOropdescriptor_t* rd) {}
 #endif
     
+#if !defined(OVERRIDE_eoprot_fun_INIT_mn_appl_cmmnds_timeset)
+EO_weak extern void eoprot_fun_INIT_mn_appl_cmmnds_timeset(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_mn_appl_cmmnds_timeset)
+EO_weak extern void eoprot_fun_UPDT_mn_appl_cmmnds_timeset(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif    
     
 // -- info
     

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMN_rom.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMN_rom.c
@@ -304,6 +304,20 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_mn_rom_descriptor_appl_cmmnds_go2state =
 #endif
 };
 
+static EOPROT_ROMmap EOnv_rom_t eoprot_mn_rom_descriptor_appl_cmmnds_timeset =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_mn_rom_appl_defaultvalue.cmmnds.timeset),
+    EO_INIT(.rwmode)    eoprot_rwm_mn_appl_cmmnds_timeset,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_mn_rom_appl_defaultvalue.cmmnds.timeset,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_mn_appl_cmmnds_timeset,
+    EO_INIT(.update)    eoprot_fun_UPDT_mn_appl_cmmnds_timeset
+#endif
+};
 
 // - descriptors for the variables of a info
 
@@ -470,7 +484,8 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_mn_rom_appl_descriptors[] =
     &eoprot_mn_rom_descriptor_appl_config,
     &eoprot_mn_rom_descriptor_appl_config_txratedivider,
     &eoprot_mn_rom_descriptor_appl_status,
-    &eoprot_mn_rom_descriptor_appl_cmmnds_go2state     
+    &eoprot_mn_rom_descriptor_appl_cmmnds_go2state,
+    &eoprot_mn_rom_descriptor_appl_cmmnds_timeset   
 };  EO_VERIFYsizeof(s_eoprot_mn_rom_appl_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_mn_appl_numberof))
 
 
@@ -559,7 +574,8 @@ static const char * const s_eoprot_mn_strings_tags_appl[] =
     "eoprot_tag_mn_appl_config",
     "eoprot_tag_mn_appl_config_txratedivider",
     "eoprot_tag_mn_appl_status",
-    "eoprot_tag_mn_appl_cmmnds_go2state"
+    "eoprot_tag_mn_appl_cmmnds_go2state",
+    "eoprot_tag_mn_appl_cmmnds_timeset"
 };  EO_VERIFYsizeof(s_eoprot_mn_strings_tags_appl, eoprot_tags_mn_appl_numberof*sizeof(const char*)) 
 
 

--- a/eth/embobj/plus/comm-v2/transport/EOtheInfoDispatcher.c
+++ b/eth/embobj/plus/comm-v2/transport/EOtheInfoDispatcher.c
@@ -434,7 +434,9 @@ static eOresult_t s_eo_infodispatcher_transmit(EOtheInfoDispatcher* p, eOmn_info
         size = p->ropsizeinfostatus;        
     }
     
-    
+    #warning: acemor, pls read here
+    // eo_transmitter_occasional_rops_LoadStream() carica uno stream in un ropframe, quello ropframeoccasionals del trasmitter
+    // nel ns caso pero'... usiamo un ropframe generico in c ad esempio. e poi quando serve lo trasmettiamo su un socket. tutto in c.
 
     res = eo_transmitter_occasional_rops_LoadStream(p->transmitter, p->ropstream, size);
     


### PR DESCRIPTION
This PR is associated with a [PR](https://github.com/robotology/icub-firmware/pull/117) in `icub-firmware` with the same name.

The purpose of these two joint PRs is to give to the ETH boards the possibility to synchronize their clock reference by means of suitable messages which carry the desired time in micro-seconds format. 

In `icub-firmware-shared` there is the format specification of such messages which belong to the management endpoint, application entity and have tag `eoprot_tag_mn_appl_cmmnds_timeset`. The message is hence:
`set<ID(management, application, 0, eoprot_tag_mn_appl_cmmnds_timeset), microsecondvalue>`

In `icub-firmware` there is the use of such messages by the boards `ems`, `mc4plus`, `mc2plus`.

For details of how the firmware of the ETH boards use this feature, see the associated [PR](https://github.com/robotology/icub-firmware/pull/117) on `icub-firmware`