### PR TITLE
embot::core::delay() renamed into embot::core::wait()

### DIFF
--- a/embot/core/embot_core.cpp
+++ b/embot/core/embot_core.cpp
@@ -76,8 +76,8 @@ namespace embot { namespace core {
     {
         return s_timenow();
     } 
-
-    void delay(embot::core::relTime t)
+    
+    void wait(embot::core::relTime t)
     {
         embot::core::Time end = now() + t;
         for(;;)
@@ -87,7 +87,7 @@ namespace embot { namespace core {
                 return;
             }
         }
-    } 
+    }
 
     int print(const std::string &str)
     {

--- a/embot/core/embot_core.h
+++ b/embot/core/embot_core.h
@@ -184,8 +184,8 @@ namespace embot { namespace core {
     bool init(const Config &config);
 
     embot::core::Time now();
-    
-    void delay(embot::core::relTime t);
+        
+    void wait(embot::core::relTime t);
 
     int print(const std::string &str);
     


### PR DESCRIPTION
as per title. it is just a change in name.

the funtion `embot::core::delay()` was introduced in https://github.com/robotology/icub-firmware-shared/commit/ec83b8aab726672f8468d73789f859f2ebd464ad and was used only in `icub-firmware`, where is now substituted w/ `embot::core::wait()`.
