### PR TITLE
ETH boards - added remote address configurator

### DIFF
--- a/eth/embobj/plus/comm-v2/transport/EOtransceiver.c
+++ b/eth/embobj/plus/comm-v2/transport/EOtransceiver.c
@@ -314,15 +314,18 @@ extern eOresult_t eo_transceiver_Receive(EOtransceiver *p, EOpacket *pkt, uint16
     
     // remember: we process a packet only if the source ipaddress is the same as in p->cfg.remipv4addr. the source port can be any.
     eo_packet_Addressing_Get(pkt, &remaddr, &remport);
-    if(remaddr != p->cfg.remipv4addr)
-    {
-        return(eores_NOK_generic);
-    }
+    
+    eo_transmitter_outpacket_SetRemoteAddress(p->transmitter, remaddr,  remport);
+    
+//    if(remaddr != p->cfg.remipv4addr)
+//    {
+//        return(eores_NOK_generic);
+//    }
     
     if(eores_OK != (res = eo_receiver_Process(p->receiver, pkt, numberofrops, &thereisareply, txtime)))
     {
         return(res);
-    }  
+    }      
 
     if(eobool_true == thereisareply)
     {

--- a/eth/embobj/plus/comm-v2/transport/EOtransmitter.c
+++ b/eth/embobj/plus/comm-v2/transport/EOtransmitter.c
@@ -1185,6 +1185,26 @@ extern eOresult_t eo_transmitter_TXdecimation_Set(EOtransmitter *p, uint8_t repl
     return(eores_NOK_nullpointer);       
 }
 
+extern eOresult_t eo_transmitter_outpacket_SetRemoteAddress(EOtransmitter *p, eOipv4addr_t remaddr, eOipv4port_t remport)
+{
+    if(NULL == p) 
+    {
+        return(eores_NOK_generic);
+    }
+    eOipv4addr_t ra = 0;
+    eOipv4port_t rp = 0;
+    eo_packet_Addressing_Get(p->txpacket, &ra, &rp);
+        
+    if((ra != remaddr) || (rp != remport))
+    {
+        p->ipv4addr = remaddr;
+        p->ipv4port = remport;
+        eo_packet_Addressing_Set(p->txpacket, remaddr, remport);
+    }
+    
+    return(eores_OK);
+}
+
 extern eOresult_t eo_transmitter_outpacket_Get(EOtransmitter *p, EOpacket **outpkt)
 {
     uint16_t size;

--- a/eth/embobj/plus/comm-v2/transport/EOtransmitter.h
+++ b/eth/embobj/plus/comm-v2/transport/EOtransmitter.h
@@ -137,6 +137,8 @@ extern eOresult_t eo_transmitter_NumberofOutROPs(EOtransmitter *p, uint16_t *num
  **/
 extern eOresult_t eo_transmitter_outpacket_Prepare(EOtransmitter *p, uint16_t *numberofrops, eOtransmitter_ropsnumber_t *ropsnum);
 
+extern eOresult_t eo_transmitter_outpacket_SetRemoteAddress(EOtransmitter *p, eOipv4addr_t remaddr, eOipv4port_t remport);
+
 
 /** @fn         extern eOresult_t eo_transmitter_outpacket_Get(EOtransmitter *p, EOpacket **outpkt)
     @brief      returns a pointer to the out packet. it is well formed only if eo_transmitter_outpacket_Prepare() 


### PR DESCRIPTION
Added configurator for the remote address to work with eth boards with a different subnet than the standard 10.0.1.104

## TEST
The software has been compiled also on the Linux machine running `yarprobotinterface` and it works.

Below an example of `yarprobotinterface` running with a gateway set to `10.0.2.104` connected to an `ems4` board with address `10.0.2.1` and an `F/T` sensor (`strain2`) connected to it

![image](https://user-images.githubusercontent.com/6638215/102191949-64bed800-3eba-11eb-9626-b40662c253d0.png)

cc @marcoaccame @pattacini 


