### PR TITLE
POS service

### DIFF
--- a/eth/embobj/core/core/EOaction.h
+++ b/eth/embobj/core/core/EOaction.h
@@ -73,7 +73,7 @@ typedef struct EOaction_hid EOaction;
 
 
 enum { EOaction_sizeof = 32 };
-typedef uint8_t EOaction_strg[EOaction_sizeof];
+typedef uint64_t EOaction_strg[EOaction_sizeof/sizeof(uint64_t)];
 
     
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -86,7 +86,8 @@ static const char * s_eoas_sensors_strings[] =
     "eoas_imu_grv",
     "eoas_imu_status",
     "eoas_temperature",
-    "eoas_psc_angle"
+    "eoas_psc_angle",
+    "eoas_pos_angle"
 };  EO_VERIFYsizeof(s_eoas_sensors_strings, eoas_sensors_numberof*sizeof(const char *));    
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -76,12 +76,13 @@ typedef enum
     eoas_imu_status             = 14,
     eoas_temperature            = 15,
     eoas_psc_angle              = 16,
+    eoas_pos_angle              = 17,
     // add in here eoas_xxxnameetc
     eoas_unknown                = 254,  
     eoas_none                   = 255   
 } eOas_sensor_t;
 
-enum { eoas_sensors_numberof = 17 };
+enum { eoas_sensors_numberof = 18 };
 
 
 /** @typedef    typedef enum eOas_entity_t;
@@ -95,10 +96,11 @@ typedef enum
     eoas_entity_temperature                 = 2,    
     eoas_entity_inertial                    = 3,
     eoas_entity_inertial3                   = 4,
-    eoas_entity_psc                         = 5
+    eoas_entity_psc                         = 5,
+    eoas_entity_pos                         = 6
 } eOas_entity_t;
 
-enum { eoas_entities_numberof = 6 };
+enum { eoas_entities_numberof = 7 };
 
 
 // -- all the possible enum
@@ -589,7 +591,7 @@ typedef struct
 
 typedef struct
 {
-    eOas_psc_arrayof_data_t         arrayofdata;   /**< it is the most recent reading of the inertial sensors which are related to this entity */
+    eOas_psc_arrayof_data_t         arrayofdata;   /**< it is the most recent reading which are related to this entity */
 } eOas_psc_status_t;                EO_VERIFYsizeof(eOas_psc_status_t, 16)
 
 
@@ -605,6 +607,69 @@ typedef struct                      // size is: 4+16+4 = 24
     eOas_psc_status_t               status;
     eOas_psc_commands_t             cmmnds;
 } eOas_psc_t;                       EO_VERIFYsizeof(eOas_psc_t, 24)
+
+
+// -- the definition of a pos sensor service
+
+// we use this struct to send activate-verify command to the board
+//enum { eOas_pos_boardinfos_maxnumber = 4 };
+//typedef struct
+//{   //6*4=24
+//    eObrd_info_t                    data[eOas_pos_boardinfos_maxnumber];
+//} eOas_pos_setof_boardinfos_t; EO_VERIFYsizeof(eOas_pos_setof_boardinfos_t, 24)
+
+//enum { eOas_pos_boards_maxnumber = 3 };
+//typedef struct
+//{
+//    eObrd_canproperties_t           canprop[eOas_pos_boards_maxnumber];
+//} eOas_pos_canPropertiesInfo_t;
+
+enum { eOas_pos_boards_maxnumber = 1 };
+typedef struct
+{
+    eObrd_canlocation_t                 canloc[eOas_pos_boards_maxnumber];
+} eOas_pos_canLocationsInfo_t;
+
+// a single pos sensor contains an angle expressed in deci-degrees 
+// this struct describes the data acquired by a single pos sensor
+typedef struct
+{
+    int16_t     value;              // so far the only value. we use int16 which contains a deci-degree.
+} eOas_pos_data_t;                  EO_VERIFYsizeof(eOas_pos_data_t, 2)
+
+typedef struct
+{
+    uint8_t                         datarate;       /**< it specifies the acquisition rate in ms  */
+    uint8_t                         filler[3];
+} eOas_pos_config_t;                EO_VERIFYsizeof(eOas_pos_config_t, 4)
+
+
+enum { eOas_pos_data_maxnumber = 14 };
+typedef struct
+{   // 4+(2*14) = 32
+    eOarray_head_t                  head;
+    eOas_pos_data_t                 data[eOas_pos_data_maxnumber];
+} eOas_pos_arrayof_data_t;          EO_VERIFYsizeof(eOas_pos_arrayof_data_t, 32)
+
+
+typedef struct
+{
+    eOas_pos_arrayof_data_t         arrayofdata;   /**< it is the most recent reading which are related to this entity */
+} eOas_pos_status_t;                EO_VERIFYsizeof(eOas_pos_status_t, 32)
+
+
+typedef struct
+{
+    uint8_t                         enable;         /**< use 0 or 1*/
+    uint8_t                         filler[3];
+} eOas_pos_commands_t;              EO_VERIFYsizeof(eOas_pos_commands_t, 4)
+
+typedef struct                      // size is: 4+32+4 = 40
+{
+    eOas_pos_config_t               config;
+    eOas_pos_status_t               status;
+    eOas_pos_commands_t             cmmnds;
+} eOas_pos_t;                       EO_VERIFYsizeof(eOas_pos_t, 40)
 
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------
 // empty-section

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -311,13 +311,22 @@ const eoerror_valuestring_t eoerror_valuestrings_CFG[] =
     
     {eoerror_value_CFG_inertials_failed_notsupported, "CFG: EOtheInertials cannot be configured. This board does not support this service."},
     {eoerror_value_CFG_inertials3_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_temperatures_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_mais_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_strain_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_skin_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_psc_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_mc_failed_notsupported, "CFG: EOtheInertials3 cannot be configured. This board does not support this service."},
-    {eoerror_value_CFG_encoders_failed_notsupported, "CFG: EOtheEncoderReader cannot be configured. This board does not support this service."}
+    {eoerror_value_CFG_temperatures_failed_notsupported, "CFG: EOtheTemperatures cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_mais_failed_notsupported, "CFG: EOtheMAIS cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_strain_failed_notsupported, "CFG: EOtheSTRAIN cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_skin_failed_notsupported, "CFG: EOtheSKIN cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_psc_failed_notsupported, "CFG: EOthePSC cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_mc_failed_notsupported, "CFG: EOtheMotionController cannot be configured. This board does not support this service."},
+    {eoerror_value_CFG_encoders_failed_notsupported, "CFG: EOtheEncoderReader cannot be configured. This board does not support this service."},
+    
+    {eoerror_value_CFG_pos_ok, "CFG: EOthePOS can be correctly configured. can address in p16, prot and vers in p64 lower 32 bits"},
+    {eoerror_value_CFG_pos_failed_candiscovery, "CFG: EOthePOS cannot be configured. can discovery fails. can address in p16, prot and vers in p64 lower 32 bits"},
+    {eoerror_value_CFG_pos_failed_verify_because_active, "CFG: EOthePOS cannot be configured. it was already activated with different configuration."},
+    {eoerror_value_CFG_pos_not_verified_yet, "CFG: EOthePOS service was not verified yet, thus it cannot start."},  
+    {eoerror_value_CFG_pos_using_onboard_config, "CFG: EOthePOS service is using the local default configuration based on its IP address."},    
+    {eoerror_value_CFG_pos_changed_requestedrate, "CFG: EOthePOS has changed the requested rate. in p16 the requested (MSB) and the assigned (LSB)."},
+    {eoerror_value_CFG_pos_failed_notsupported, "CFG: EOthePOS cannot be configured. This board does not support this service."},
+    
     
 };  EO_VERIFYsizeof(eoerror_valuestrings_CFG, eoerror_value_CFG_numberof*sizeof(const eoerror_valuestring_t))
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -369,10 +369,19 @@ typedef enum
     eoerror_value_CFG_skin_failed_notsupported = 73,
     eoerror_value_CFG_psc_failed_notsupported = 74,
     eoerror_value_CFG_mc_failed_notsupported = 75,
-    eoerror_value_CFG_encoders_failed_notsupported = 76
+    eoerror_value_CFG_encoders_failed_notsupported = 76,
+    
+    eoerror_value_CFG_pos_ok                            = 77,
+    eoerror_value_CFG_pos_failed_candiscovery           = 78,
+    eoerror_value_CFG_pos_failed_verify_because_active  = 79,
+    eoerror_value_CFG_pos_not_verified_yet              = 80,
+    eoerror_value_CFG_pos_using_onboard_config          = 81,
+    eoerror_value_CFG_pos_changed_requestedrate         = 82,
+    eoerror_value_CFG_pos_failed_notsupported           = 83
+    
 } eOerror_value_CFG_t;
 
-enum { eoerror_value_CFG_numberof = 77 };
+enum { eoerror_value_CFG_numberof = 84 };
 
 
 /** @typedef    typedef enum eOerror_value_ETHMON_t

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.c
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.c
@@ -82,7 +82,10 @@ static const char * s_mn_servicetype_strings[] =
     "eomn_serv_AS_temperature",
     "eomn_serv_MC_mc2plus", 
     "eomn_serv_MC_mc2pluspsc",
-    "eomn_serv_AS_psc"
+    "eomn_serv_AS_psc",
+    "eomn_serv_AS_pos",
+    "eomn_serv_MC_mc4plusfaps",
+    "eomn_serv_MC_mc4pluspmc"
 };  EO_VERIFYsizeof(s_mn_servicetype_strings, eomn_serv_types_numberof*sizeof(const char *))   
  
 static const char * s_mn_servicetype_string_unknown = "eomn_serv_UNKNOWN";

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -434,12 +434,13 @@ typedef enum
     eomn_serv_category_inertials3       = 5,
     eomn_serv_category_temperatures     = 6,
     eomn_serv_category_psc              = 7,
+    eomn_serv_category_pos              = 8,
     eomn_serv_category_all              = 128,
     eomn_serv_category_unknown          = 254,
     eomn_serv_category_none             = 255
 } eOmn_serv_category_t;
 
-enum { eomn_serv_categories_numberof = 8 };
+enum { eomn_serv_categories_numberof = 9 };
 
 typedef enum 
 {
@@ -457,11 +458,14 @@ typedef enum
     eomn_serv_MC_mc2plus        = 11,
     eomn_serv_MC_mc2pluspsc     = 12,
     eomn_serv_AS_psc            = 13,
+    eomn_serv_AS_pos            = 14,
+    eomn_serv_MC_mc4plusfaps    = 15,
+    eomn_serv_MC_mc4pluspmc     = 16,
     eomn_serv_UNKNOWN           = 254,
     eomn_serv_NONE              = 255
 } eOmn_serv_type_t;
 
-enum { eomn_serv_types_numberof = 14 };
+enum { eomn_serv_types_numberof = 17 };
 
 
 
@@ -508,14 +512,23 @@ typedef struct
     eOas_psc_canLocationsInfo_t         boardInfo;
 } eOmn_serv_config_data_as_psc_t;       EO_VERIFYsizeof(eOmn_serv_config_data_as_psc_t, 8)
 
+
+typedef struct
+{   
+    eObrd_version_t                     version;
+    eOas_pos_canLocationsInfo_t         boardInfo;
+} eOmn_serv_config_data_as_pos_t;       EO_VERIFYsizeof(eOmn_serv_config_data_as_pos_t, 6)
+
+
 typedef union
-{   // max(6, 6, 44, 108, 156, 8)
+{   // max(6, 6, 44, 108, 156, 8, 6)
     eOmn_serv_config_data_as_mais_t         mais;
     eOmn_serv_config_data_as_strain_t       strain;
     eOmn_serv_config_data_as_temperature_t  temperature;
     eOmn_serv_config_data_as_inertial_t     inertial;  
     eOmn_serv_config_data_as_inertial3_t    inertial3;
     eOmn_serv_config_data_as_psc_t          psc;
+    eOmn_serv_config_data_as_pos_t          pos;
 } eOmn_serv_config_data_as_t;               EO_VERIFYsizeof(eOmn_serv_config_data_as_t, 156)
 
 
@@ -691,20 +704,21 @@ typedef struct
 
 
 typedef struct
-{   // 8 + 32
-    uint8_t                                 stateofservice[eomn_serv_categories_numberof];     // use eOmn_serv_state_t  
+{   // 32 + 32
+    uint8_t                                 stateofservice[eomn_serv_categories_numberof];     // use eOmn_serv_state_t
+    uint8_t                                 filler[7];    
     eOmn_service_command_result_t           commandresult;
-} eOmn_service_status_t;                    EO_VERIFYsizeof(eOmn_service_status_t, 40) 
+} eOmn_service_status_t;                    EO_VERIFYsizeof(eOmn_service_status_t, 48) 
 
 
 /** @typedef    typedef struct eOmn_service_t;
     @brief      used to represent the info with config, status
  **/
 typedef struct                      
-{   // 40+332=372    
+{   // 48+336=372    
     eOmn_service_status_t                   status;
     eOmn_service_cmmnds_t                   cmmnds;
-} eOmn_service_t;                           EO_VERIFYsizeof(eOmn_service_t, 376)  
+} eOmn_service_t;                           EO_VERIFYsizeof(eOmn_service_t, 384)  
 
 
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -91,6 +91,7 @@ static const eOmap_str_str_u08_t s_eomc_map_of_encoders[] =
     {"spichainof3", "eomc_enc_spichainof3", eomc_enc_spichainof3},    
     {"amo", "eomc_enc_amo", eomc_enc_amo},
     {"psc", "eomc_enc_psc", eomc_enc_psc},
+    {"pos", "eomc_enc_pos", eomc_enc_pos},
 
     {"none", "eomc_enc_none", eomc_enc_none},
     {"unknown", "eomc_enc_unknown", eomc_enc_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -1087,12 +1087,13 @@ typedef enum
     eomc_enc_spichainof3    = 8,    
     eomc_enc_amo            = 9, 
     eomc_enc_psc            = 10,
+    eomc_enc_pos            = 11,
     
     eomc_enc_none           = 0,
     eomc_enc_unknown        = 255    
 } eOmc_encoder_t;
 
-enum { eomc_encoders_numberof = 10 };
+enum { eomc_encoders_numberof = 11 };
 enum { eomc_encoders_maxnumberofcomponents = 4 };
 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
@@ -214,12 +214,13 @@ typedef enum
     eoprot_entity_as_temperature            = eoas_entity_temperature,  /**<  */  
     eoprot_entity_as_inertial               = eoas_entity_inertial,     /**<  */   
     eoprot_entity_as_inertial3              = eoas_entity_inertial3,    /**<  */  
-    eoprot_entity_as_psc                    = eoas_entity_psc,          /**<  */    
+    eoprot_entity_as_psc                    = eoas_entity_psc,          /**<  */   
+    eoprot_entity_as_pos                    = eoas_entity_pos,          /**<  */        
     eoprot_entity_sk_skin                   = eosk_entity_skin,         /**<  */
     eoprot_entity_none                      = EOK_uint08dummy
 } eOprot_entity_t;
 
-enum { eoprot_entities_numberof = 14 }; // it does not count the eoprot_entity_none.
+enum { eoprot_entities_numberof = 15 }; // it does not count the eoprot_entity_none.
 
 
 /** @typedef    typedef enum eOprot_index_t

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
@@ -279,6 +279,39 @@ enum { eoprot_rwms_as_psc_numberof = 4 };  // it MUST be equal to the number of 
 
 
 
+// - entity pos
+
+
+/** @typedef    typedef enum eOprot_tag_as_pos_t
+    @brief      It contains the tags for all variables of the psc entity.
+                See definition of eOas_pos_t (and its fields) in file EoAnalogSensors.h for explanation of the variables.
+ **/
+typedef enum
+{
+    eoprot_tag_as_pos_wholeitem                                     = 0,
+    eoprot_tag_as_pos_config                                        = 1,
+    eoprot_tag_as_pos_status                                        = 2,
+    eoprot_tag_as_pos_cmmnds_enable                                 = 3
+} eOprot_tag_as_pos_t;
+
+enum { eoprot_tags_as_pos_numberof = 4 };  // it MUST be equal to the number of tags. 
+
+
+/** @typedef    typedef enum eOprot_rwm_as_pos_t
+    @brief      It contains the rw modes for all variables of the pos entity. There must be a one-to-one
+                correspondence to the values in eOprot_tag_as_pos_t.
+ **/
+typedef enum
+{
+    eoprot_rwm_as_pos_wholeitem                                     = eo_nv_rwmode_RO,
+    eoprot_rwm_as_pos_config                                        = eo_nv_rwmode_RW,
+    eoprot_rwm_as_pos_status                                        = eo_nv_rwmode_RO,
+    eoprot_rwm_as_pos_cmmnds_enable                                 = eo_nv_rwmode_RW    
+} eOprot_rwm_as_pos_t; 
+
+enum { eoprot_rwms_as_pos_numberof = 4 };  // it MUST be equal to the number of rw modes. 
+
+
 
 // - structures implementing the endpoints
 
@@ -294,6 +327,7 @@ typedef struct                  // 56*1+48*1+8*1 = 112
     eOas_inertial_t             inertial[1];
     eOas_inertial3_t            inertial3[1];
     eOas_psc_t                  psc[1];
+    eOas_pos_t                  pos[1];
 } eOprot_template_as_t;         //EO_VERIFYsizeof(eOprot_template_as_t, 112);
   
   
@@ -424,6 +458,19 @@ extern void eoprot_fun_UPDT_as_psc_status(const EOnv* nv, const eOropdescriptor_
 extern void eoprot_fun_INIT_as_psc_cmmnds_enable(const EOnv* nv);
 extern void eoprot_fun_UPDT_as_psc_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd);
 
+// -- pos
+
+extern void eoprot_fun_INIT_as_pos_wholeitem(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_pos_wholeitem(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_pos_config(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_pos_config(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_pos_status(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_pos_status(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_pos_cmmnds_enable(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_pos_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd);
 
 
 /** @}            

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 4 };
+enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 5 };
 
 
 enum { eoprot_entities_as_numberof = eoas_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 16 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 17 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocol.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocol.c
@@ -132,7 +132,7 @@ const eOprot_EPcfg_t eoprot_arrayof_stdEPcfg[eoprot_endpoints_numberof] =
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 0}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,
@@ -153,7 +153,7 @@ const eOprot_EPcfg_t eoprot_arrayof_maxEPcfg[eoprot_endpoints_numberof] =
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 0}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,
@@ -170,7 +170,7 @@ const eOprot_EPcfg_t eoprot_arrayof_maxEPcfgOthers[eoprot_endpoints_numberof-1] 
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 0}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_fun.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_fun.c
@@ -343,7 +343,36 @@ EO_weak extern void eoprot_fun_INIT_as_psc_cmmnds_enable(const EOnv* nv) {}
 EO_weak extern void eoprot_fun_UPDT_as_psc_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd) {}
 #endif    
     
+// -- pos 
 
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_pos_wholeitem)
+EO_weak extern void eoprot_fun_INIT_as_pos_wholeitem(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_pos_wholeitem)
+EO_weak extern void eoprot_fun_UPDT_as_pos_wholeitem(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_pos_config)
+EO_weak extern void eoprot_fun_INIT_as_pos_config(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_pos_config)
+EO_weak extern void eoprot_fun_UPDT_as_pos_config(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_pos_status)
+EO_weak extern void eoprot_fun_INIT_as_pos_status(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_pos_status)
+EO_weak extern void eoprot_fun_UPDT_as_pos_status(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_pos_cmmnds_enable)
+EO_weak extern void eoprot_fun_INIT_as_pos_cmmnds_enable(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_pos_cmmnds_enable)
+EO_weak extern void eoprot_fun_UPDT_as_pos_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif    
+    
 #endif//!defined(EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME)
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_rom.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_rom.c
@@ -105,6 +105,9 @@ static const eOas_inertial3_t eoprot_as_rom_inertial3_defaultvalue = { 0 };
 // - default value of a psc
 static const eOas_psc_t eoprot_as_rom_psc_defaultvalue = { 0 };
 
+// - default value of a pos
+static const eOas_psc_t eoprot_as_rom_pos_defaultvalue = { 0 };
+
 // - descriptors for the variables of a strain
 
 static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_strain_wholeitem =
@@ -592,7 +595,69 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_psc_cmmnds_enable =
 #endif
 };
 
+// - descriptors for the variables of a pos
 
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_pos_wholeitem =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_pos_defaultvalue),
+    EO_INIT(.rwmode)    eoprot_rwm_as_pos_wholeitem,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_pos_defaultvalue,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_pos_wholeitem,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_pos_wholeitem
+#endif
+};
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_pos_config =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_pos_defaultvalue.config),
+    EO_INIT(.rwmode)    eoprot_rwm_as_pos_config,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_pos_defaultvalue.config,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_pos_config,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_pos_config
+#endif
+};
+
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_pos_status =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_pos_defaultvalue.status),
+    EO_INIT(.rwmode)    eoprot_rwm_as_pos_status,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_pos_defaultvalue.status,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_pos_status,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_pos_status
+#endif
+};
+
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_pos_cmmnds_enable =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_pos_defaultvalue.cmmnds.enable),
+    EO_INIT(.rwmode)    eoprot_rwm_as_pos_cmmnds_enable,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_pos_defaultvalue.cmmnds.enable,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_pos_cmmnds_enable,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_pos_cmmnds_enable
+#endif
+};
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
@@ -663,6 +728,14 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_psc_descriptors[] =
     &eoprot_as_rom_descriptor_psc_cmmnds_enable
 };  EO_VERIFYsizeof(s_eoprot_as_rom_psc_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_psc_numberof))
 
+static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_pos_descriptors[] =
+{   // here are eoprot_tags_as_inertial_numberof descriptors for the inertial entity
+    &eoprot_as_rom_descriptor_pos_wholeitem,
+    &eoprot_as_rom_descriptor_pos_config,
+    &eoprot_as_rom_descriptor_pos_status,
+    &eoprot_as_rom_descriptor_pos_cmmnds_enable
+};  EO_VERIFYsizeof(s_eoprot_as_rom_pos_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_pos_numberof))
+
 EOPROT_ROMmap EOnv_rom_t * const * const eoprot_as_rom_descriptors[] = 
 {
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_strain_descriptors,
@@ -670,7 +743,8 @@ EOPROT_ROMmap EOnv_rom_t * const * const eoprot_as_rom_descriptors[] =
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_temperature_descriptors, 
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_inertial_descriptors,
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_inertial3_descriptors,
-    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_psc_descriptors
+    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_psc_descriptors,
+    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_pos_descriptors
 };  EO_VERIFYsizeof(eoprot_as_rom_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t** const)*(eoprot_entities_as_numberof))
 
 
@@ -683,7 +757,8 @@ const uint8_t eoprot_as_rom_tags_numberof[] =
     eoprot_tags_as_temperature_numberof,
     eoprot_tags_as_inertial_numberof,
     eoprot_tags_as_inertial3_numberof,
-    eoprot_tags_as_psc_numberof
+    eoprot_tags_as_psc_numberof,
+    eoprot_tags_as_pos_numberof
 };  EO_VERIFYsizeof(eoprot_as_rom_tags_numberof, eoprot_entities_as_numberof*sizeof(uint8_t)) 
 
 const uint16_t eoprot_as_rom_entities_sizeof[] = 
@@ -693,7 +768,8 @@ const uint16_t eoprot_as_rom_entities_sizeof[] =
     sizeof(eOas_temperature_t),
     sizeof(eOas_inertial_t),
     sizeof(eOas_inertial3_t),
-    sizeof(eOas_psc_t)
+    sizeof(eOas_psc_t),
+    sizeof(eOas_pos_t)
 };  EO_VERIFYsizeof(eoprot_as_rom_entities_sizeof, eoprot_entities_as_numberof*sizeof(uint16_t)) 
 
 const void* const eoprot_as_rom_entities_defval[] = 
@@ -703,7 +779,8 @@ const void* const eoprot_as_rom_entities_defval[] =
     (const void*)&eoprot_as_rom_temperature_defaultvalue,
     (const void*)&eoprot_as_rom_inertial_defaultvalue,
     (const void*)&eoprot_as_rom_inertial3_defaultvalue,
-    (const void*)&eoprot_as_rom_psc_defaultvalue
+    (const void*)&eoprot_as_rom_psc_defaultvalue,
+    (const void*)&eoprot_as_rom_pos_defaultvalue
 };  EO_VERIFYsizeof(eoprot_as_rom_entities_defval, eoprot_entities_as_numberof*sizeof(const void*)) 
 
 
@@ -716,7 +793,8 @@ const char * const eoprot_as_strings_entity[] =
     "eoprot_entity_as_temperature",
     "eoprot_entity_as_inertial",
     "eoprot_entity_as_inertial3",
-    "eoprot_entity_as_psc"
+    "eoprot_entity_as_psc",
+    "eoprot_entity_as_pos"
 };  EO_VERIFYsizeof(eoprot_as_strings_entity, eoprot_entities_as_numberof*sizeof(const char*)) 
 
 
@@ -775,6 +853,14 @@ static const char * const s_eoprot_as_strings_tags_psc[] =
     "eoprot_tag_as_psc_cmmnds_enable"
 };  EO_VERIFYsizeof(s_eoprot_as_strings_tags_psc, eoprot_tags_as_psc_numberof*sizeof(const char*))
 
+static const char * const s_eoprot_as_strings_tags_pos[] =
+{
+    "eoprot_tag_as_pos_wholeitem",
+    "eoprot_tag_as_pos_config",
+    "eoprot_tag_as_pos_status",
+    "eoprot_tag_as_pos_cmmnds_enable"
+};  EO_VERIFYsizeof(s_eoprot_as_strings_tags_pos, eoprot_tags_as_pos_numberof*sizeof(const char*))
+
 const char ** const eoprot_as_strings_tags[] =
 {
     (const char**)&s_eoprot_as_strings_tags_strain,   
@@ -782,7 +868,8 @@ const char ** const eoprot_as_strings_tags[] =
     (const char**)&s_eoprot_as_strings_tags_temperature,
     (const char**)&s_eoprot_as_strings_tags_inertial,
     (const char**)&s_eoprot_as_strings_tags_inertial3,
-    (const char**)&s_eoprot_as_strings_tags_psc
+    (const char**)&s_eoprot_as_strings_tags_psc,
+    (const char**)&s_eoprot_as_strings_tags_pos
 };  EO_VERIFYsizeof(eoprot_as_strings_tags, eoprot_entities_as_numberof*sizeof(const char**)) 
 
 


### PR DESCRIPTION
This PR introduces the `POS service`.

## Description of the service

The POS service is used to stream position values from an `ETH` board towards the relevant device started by `yarprobotinterface`, the `embObjPOS`. The values are retrieved from up to 14 encoders, so far only magnetic encoders from the `pmc` board. The POS service is required to get position values of the fingers of the new hand. 

## Changes

This PR is to be processed together with two other PRs: one for [`icub-firmware` ](https://github.com/robotology/icub-firmware/pull/147) and one for [`icub-main`](https://github.com/robotology/icub-main/pull/696).

In here are the main changes in each of these repositories. I describe them all together because one repo affects the other.

- `icub-firmware`:  added the `EOthePOS` object in ems, mc4plus, mc2plus; enabled in `EOtheServices`; added handlers for the required ETH and CAN messages. At the moment the  `EOthePOS` is disabled in the projects of the three ETH boards with macro EOTHESERVICES_disable_thePOS being defined at project level (-DEOTHESERVICES_disable_thePOS in section Misc Controls of C/C++ options).

- `icub-firmware-shared`: added the new entity `eoprot_entity_as_pos`  in endpoint `eoprot_endpoint_analogsensors` with all required stuff; added runtime configuration of the POS service inside the management entity with a new `eOmn_serv_config_data_as_pos_t`; advanced protocol versions of entities analogsensors and management.

- `icub-main`: added the `embObjPOS` device inside icubmod + all required stuff required to run the service (parser of xml files, handling of relevant ETH protocol messages); changed some of the obsolete `NetworkBase::getEnvironment()` calls with teh suggested `yarp::conf::environment::getEnvironment()`.

## Tests

All the chain was tested on a setup made of: 
- linux pc with most recent `yarp` (master branch) plus the repos under PR plus a suitable set of xml files.
- `ems` board with macro `EOTHESERVICES_disable_thePOS` disabled,
- `pmc` board with a fake acquisition of magnetic encoders.

The service runs with success and streams the values of the target YARP port. The following shows the plot from `yarpscope` reading on that port.

![Screenshot from 2020-12-02 13-46-48](https://user-images.githubusercontent.com/7148284/100874453-e2d7b380-34a4-11eb-8f87-f9ffee16b2da.png)

**Figure**. Outcome of the POS service on `yarpscope`. 

And in here is a video of one experiment. The talk is lost, hence in here i summarize the steps:
- launch yarp server w/ `yarp server`.
- launch yarprobotinterface w/ `yarprobotinterface --config handV3.xml`
- read the relevant yarp port w/ `yarp read ... /hv3/left_hand/POS:o`
- launch the yarpscope w/ `yarpscope --xml yarpscope.pos.xml`
- resizing the window which shows the time variation from sensors J4 to U27.


<img src="https://user-images.githubusercontent.com/7148284/100876764-1700a380-34a8-11eb-8c1b-4de8fc23157c.gif" width="800" height="450"/>

**Figure**. Video of one test of the POS service. 



## Impact on iCub

The above test worked fine as expected. And the changes done to support the new device are pretty standard and safe and used only if one uses the POS service by starting the `embObjPOS` device from yarprobotinterface. 

Hence, ... **I expect no harm on iCub**.
