### PR TITLE
Bump icub-firmware-shared version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.18.0)
+        VERSION 1.18.100)
 
 find_package(YCM 0.11.0 REQUIRED)
 


### PR DESCRIPTION
This is due to https://github.com/robotology/icub-firmware-shared/pull/42

It has to set as minimum required also in icub-main after https://github.com/robotology/icub-main/pull/696