### PR TITLE
Support for MC service of the new hand: open/close of fingers

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -197,6 +197,18 @@ static const eOmap_str_str_u08_t s_boards_map_of_portpscs[] =
     {"unknown", "eobrd_portpsc_unknown", eobrd_portpsc_unknown}    
 };  EO_VERIFYsizeof(s_boards_map_of_portpscs, (eobrd_portpscs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
+
+static const eOmap_str_str_u08_t s_boards_map_of_portposs[] =
+{
+    {"hand_thumb", "eobrd_portpos_hand_thumb", eobrd_portpos_hand_thumb},
+    {"hand_index", "eobrd_portpos_hand_index", eobrd_portpos_hand_index},
+    {"hand_medium", "eobrd_portpos_hand_medium", eobrd_portpos_hand_medium},
+    {"hand_pinky", "eobrd_portpos_hand_pinky", eobrd_portpos_hand_pinky},
+    
+    {"none", "eobrd_portpos_none", eobrd_portpos_none},
+    {"unknown", "eobrd_portpos_unknown", eobrd_portpos_unknown}    
+};  EO_VERIFYsizeof(s_boards_map_of_portposs, (eobrd_portposs_numberof+2)*sizeof(eOmap_str_str_u08_t))
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
 // --------------------------------------------------------------------------------------------------------------------
@@ -457,7 +469,6 @@ extern eObrd_connector_t eoboards_port2connector(eObrd_port_t port, eObrd_type_t
 }
 
 
-
 extern const char * eoboards_portmais2string(eObrd_portmais_t portmais, eObool_t usecompactstring)
 {
     const eOmap_str_str_u08_t * map = s_boards_map_of_portmaiss;
@@ -471,7 +482,6 @@ extern const char * eoboards_portmais2string(eObrd_portmais_t portmais, eObool_t
     }
     
     return(str);   
-
 }
 
 
@@ -498,7 +508,6 @@ extern const char * eoboards_portpsc2string(eObrd_portpsc_t portpsc, eObool_t us
     }
     
     return(str);   
-
 }
 
 
@@ -509,6 +518,32 @@ extern eObrd_portpsc_t eoboards_string2portpsc(const char * string, eObool_t use
     const uint8_t defvalue = eobrd_portpsc_unknown;
     
     return((eObrd_portpsc_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+}
+
+
+extern const char * eoboards_portpos2string(eObrd_portpos_t portpos, eObool_t usecompactstring)
+{
+    const eOmap_str_str_u08_t * map = s_boards_map_of_portposs;
+    const uint8_t size = eobrd_portposs_numberof+2;
+    const uint8_t value = portpos;
+    const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
+    
+    if(NULL == str)
+    {
+        str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
+    }
+    
+    return(str);   
+}
+
+
+extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t usecompactstring)
+{
+    const eOmap_str_str_u08_t * map = s_boards_map_of_portposs;
+    const uint8_t size = eobrd_portposs_numberof+2;
+    const uint8_t defvalue = eobrd_portpos_unknown;
+    
+    return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -345,6 +345,20 @@ typedef enum
 } eObrd_portpsc_t;
 
 enum { eobrd_portpscs_numberof = 2 };
+
+
+typedef enum
+{
+    eobrd_portpos_hand_thumb        = 0,
+    eobrd_portpos_hand_index        = 1,
+    eobrd_portpos_hand_medium       = 2,
+    eobrd_portpos_hand_pinky        = 3,
+
+    eobrd_portpos_none              = 31,    // as ... eobrd_port_none
+    eobrd_portpos_unknown           = 30     // as ... eobrd_port_unknown
+} eObrd_portpos_t;
+
+enum { eobrd_portposs_numberof = 4 };
     
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------
 // empty-section
@@ -384,6 +398,9 @@ extern eObrd_portmais_t eoboards_string2portmais(const char * string, eObool_t u
 
 extern const char * eoboards_portpsc2string(eObrd_portpsc_t portpsc, eObool_t usecompactstring);
 extern eObrd_portpsc_t eoboards_string2portpsc(const char * string, eObool_t usecompactstring);
+
+extern const char * eoboards_portpos2string(eObrd_portpos_t portpos, eObool_t usecompactstring);
+extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t usecompactstring);
 
     
 /** @}            

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -326,8 +326,11 @@ const eoerror_valuestring_t eoerror_valuestrings_CFG[] =
     {eoerror_value_CFG_pos_using_onboard_config, "CFG: EOthePOS service is using the local default configuration based on its IP address."},    
     {eoerror_value_CFG_pos_changed_requestedrate, "CFG: EOthePOS has changed the requested rate. in p16 the requested (MSB) and the assigned (LSB)."},
     {eoerror_value_CFG_pos_failed_notsupported, "CFG: EOthePOS cannot be configured. This board does not support this service."},
-    
-    
+
+    {eoerror_value_CFG_mc_mc4plusfaps_ok, "CFG: EOtheMotionController can correctly configure mc4plusfaps-based motion. more info will follow"},
+    {eoerror_value_CFG_mc_mc4plusfaps_failed_encoders_verify, "CFG: EOtheMotionController cannot be configured. verification of encoder fails for mc4plusfaps. see other messages for more details"},
+    {eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery_of_pmc, "CFG: EOtheMotionController cannot be configured. verification of pos for mc4plusfaps fails. see other messages for more details"},
+           
 };  EO_VERIFYsizeof(eoerror_valuestrings_CFG, eoerror_value_CFG_numberof*sizeof(const eoerror_valuestring_t))
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -377,11 +377,15 @@ typedef enum
     eoerror_value_CFG_pos_not_verified_yet              = 80,
     eoerror_value_CFG_pos_using_onboard_config          = 81,
     eoerror_value_CFG_pos_changed_requestedrate         = 82,
-    eoerror_value_CFG_pos_failed_notsupported           = 83
+    eoerror_value_CFG_pos_failed_notsupported           = 83,
+    
+    eoerror_value_CFG_mc_mc4plusfaps_ok                 = 84,
+    eoerror_value_CFG_mc_mc4plusfaps_failed_encoders_verify = 85, 
+    eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery_of_pmc = 86,    
     
 } eOerror_value_CFG_t;
 
-enum { eoerror_value_CFG_numberof = 84 };
+enum { eoerror_value_CFG_numberof = 87 };
 
 
 /** @typedef    typedef enum eOerror_value_ETHMON_t

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -592,21 +592,31 @@ typedef struct
 } eOmn_serv_config_data_mc_mc2plus_t;       EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc2plus_t, 316)
 
 typedef struct
-{   // 8+24+292=324
+{   // 8+24+292+4=328
     eOmn_serv_config_data_as_psc_t          psc;
     eOmc_arrayof_4jomodescriptors_t         arrayofjomodescriptors;  
     eOmc_4jomo_coupling_t                   jomocoupling;
     eOmc_4jomo_stopswitches_t               jomostopswitches;    
 } eOmn_serv_config_data_mc_mc2pluspsc_t;    EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc2pluspsc_t, 328)
 
+
+typedef struct
+{   // 6+2+24+292=324
+    eOmn_serv_config_data_as_pos_t          pos;
+    uint8_t                                 filler[2];
+    eOmc_arrayof_4jomodescriptors_t         arrayofjomodescriptors;  
+    eOmc_4jomo_coupling_t                   jomocoupling;
+} eOmn_serv_config_data_mc_mc4plusfaps_t;   EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc4plusfaps_t, 324)
+
 typedef union                               
-{   // max(324, 28, 316, 324)
+{   // max(324, 28, 316, 328, 324)
     eOmn_serv_config_data_mc_foc_t          foc_based;
     eOmn_serv_config_data_mc_mc4_t          mc4_based;
     eOmn_serv_config_data_mc_mc4plus_t      mc4plus_based;
     eOmn_serv_config_data_mc_mc4plusmais_t  mc4plusmais_based;
     eOmn_serv_config_data_mc_mc2plus_t      mc2plus;
     eOmn_serv_config_data_mc_mc2pluspsc_t   mc2pluspsc;
+    eOmn_serv_config_data_mc_mc4plusfaps_t  mc4plusfaps;
 } eOmn_serv_config_data_mc_t;               EO_VERIFYsizeof(eOmn_serv_config_data_mc_t, 328) 
 
 typedef union                               

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -291,6 +291,11 @@ extern uint8_t eomc_encoder_get_numberofcomponents(eOmc_encoder_t encoder)
             ret = 4;
         } break;
         
+        case eomc_enc_pos:
+        {
+            ret = 1;
+        } break;        
+        
         default:
         {
             ret = 0;


### PR DESCRIPTION
This PR adds support for the MC service `eomn_serv_MC_mc4plusfaps` and for the required encoder's ports defined inside `eObrd_portpos_t`.

This PR is associated to [PR ](https://github.com/robotology/icub-firmware/pull/148) in `icub-firmware`.

