### PR TITLE
Added info message for error reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.19.0)
+        VERSION 1.19.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -192,8 +192,9 @@ const eoerror_valuestring_t eoerror_valuestrings_MC[] =
     {eoerror_value_MC_motor_qencoder_phase,  "MC: 2FOC quadrature encoder phase broken. The motor encoder is not counting even if the motor is moving, please check motor encoder cables. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
     {eoerror_value_MC_generic_error,         "MC: generic motor error (see 64 bit mask parameter)."},
     {eoerror_value_MC_motor_wrong_state,     "MC: 2FOC wrong state. The 2FOC motor controller is in a control state different from required by the EMS. In par64 0xF0 is the mask of requested state, 0x0F is the mask of actual state. par16 = ID of joint."},
-    {eoerror_value_MC_joint_hard_limit,      "MC: hard limit reached. The joint position is outside its hardware boundaries. par16 = ID of joint."}
-    
+    {eoerror_value_MC_joint_hard_limit,      "MC: hard limit reached. The joint position is outside its hardware boundaries. par16 = ID of joint."},
+    {eoerror_value_MC_motor_qencoder_phase_disappeared, "MC: qenc error has disappeared, warning counter has been reset."}
+
 };  EO_VERIFYsizeof(eoerror_valuestrings_MC, eoerror_value_MC_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -221,10 +221,11 @@ typedef enum
     eoerror_value_MC_generic_error                  = 14,
     eoerror_value_MC_motor_wrong_state              = 15,
     
-    eoerror_value_MC_joint_hard_limit               = 16
+    eoerror_value_MC_joint_hard_limit               = 16,
+    eoerror_value_MC_motor_qencoder_phase_disappeared   = 17
 } eOerror_value_MC_t;
 
-enum { eoerror_value_MC_numberof = 17 };
+enum { eoerror_value_MC_numberof = 18 };
 
 
 


### PR DESCRIPTION
This pull-request is a child of this other pull-request: [https://github.com/robotology/icub-firmware/pull/170](https://github.com/robotology/icub-firmware/pull/170).

It complements that pull-request to allow sending an info message when the encoder error disappears and the warning message counter is reset.

CC @marcoaccame @pattacini 