### PR TITLE
AMO diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.20.0)
+        VERSION 1.20.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.c
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.c
@@ -156,7 +156,7 @@ extern eOmn_serv_type_t eomn_string2servicetype(const char * string)
 
 extern const char * eomn_servicediagnmode2string(eOmn_serv_diagn_mode_t diagnmode)
 {
-    const char * ret = s_mn_servicediagnmode_strings[eOmn_serv_diagn_mode_UNKNOWN];
+    const char * ret = s_mn_servicediagnmode_strings[eomn_serv_diagn_mode_UNKNOWN];
     
     if(diagnmode < eomn_serv_diagn_mode_numberof)
     {
@@ -172,7 +172,7 @@ extern eOmn_serv_diagn_mode_t eomn_string2servicediagnmode(const char * string)
     
     if(NULL == string)
     {
-        return(eOmn_serv_diagn_mode_UNKNOWN);
+        return(eomn_serv_diagn_mode_UNKNOWN);
     }
       
     for(i=0; i<eomn_serv_diagn_mode_numberof; i++)
@@ -183,7 +183,7 @@ extern eOmn_serv_diagn_mode_t eomn_string2servicediagnmode(const char * string)
         }
     }       
     
-    return(eOmn_serv_diagn_mode_UNKNOWN);    
+    return(eomn_serv_diagn_mode_UNKNOWN);    
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.c
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.c
@@ -92,6 +92,15 @@ static const char * s_mn_servicetype_string_unknown = "eomn_serv_UNKNOWN";
 static const char * s_mn_servicetype_string_none = "eomn_serv_NONE";
 
 
+static const char * s_mn_servicediagnmode_strings[] =
+{
+    "eomn_serv_diagn_mode_NONE",
+    "eomn_serv_diagn_mode_UNKNOWN",
+    "eomn_serv_diagn_mode_MC_AMO",
+    "eomn_serv_diagn_mode_MC_ENC"
+};  EO_VERIFYsizeof(s_mn_servicediagnmode_strings, eomn_serv_diagn_mode_numberof*sizeof(const char *))   
+ 
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
 // --------------------------------------------------------------------------------------------------------------------
@@ -142,6 +151,39 @@ extern eOmn_serv_type_t eomn_string2servicetype(const char * string)
     }        
     
     return(eomn_serv_UNKNOWN);    
+}
+
+
+extern const char * eomn_servicediagnmode2string(eOmn_serv_diagn_mode_t diagnmode)
+{
+    const char * ret = s_mn_servicediagnmode_strings[eOmn_serv_diagn_mode_UNKNOWN];
+    
+    if(diagnmode < eomn_serv_diagn_mode_numberof)
+    {
+        return(s_mn_servicediagnmode_strings[diagnmode]);
+    }
+
+    return(ret);
+}
+
+extern eOmn_serv_diagn_mode_t eomn_string2servicediagnmode(const char * string)
+{     
+    uint8_t i = 0;   
+    
+    if(NULL == string)
+    {
+        return(eOmn_serv_diagn_mode_UNKNOWN);
+    }
+      
+    for(i=0; i<eomn_serv_diagn_mode_numberof; i++)
+    {
+        if(0 == strcmp(string, s_mn_servicediagnmode_strings[i]))
+        {
+            return((eOmn_serv_diagn_mode_t)(i+0));
+        }
+    }       
+    
+    return(eOmn_serv_diagn_mode_UNKNOWN);    
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -469,10 +469,10 @@ enum { eomn_serv_types_numberof = 17 };
 
 typedef enum
 {
-    eOmn_serv_diagn_mode_NONE       = 0, // put in here for backwards compatibility ...
-    eOmn_serv_diagn_mode_UNKNOWN    = 1,
-    eOmn_serv_diagn_mode_MC_AMO     = 2,
-    eOmn_serv_diagn_mode_MC_ENC     = 3
+    eomn_serv_diagn_mode_NONE       = 0, // put in here for backwards compatibility ...
+    eomn_serv_diagn_mode_UNKNOWN    = 1,
+    eomn_serv_diagn_mode_MC_AMO     = 2,
+    eomn_serv_diagn_mode_MC_ENC     = 3
 } eOmn_serv_diagn_mode_t;
 
 enum { eomn_serv_diagn_mode_numberof = 4 };

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -478,6 +478,12 @@ typedef enum
 enum { eomn_serv_diagn_mode_numberof = 4 };
 
 typedef struct
+{
+    uint8_t     mode;   // use eOmn_serv_diagn_mode_t
+    uint16_t    par16;    
+} eOmn_serv_diagn_cfg_t;
+
+typedef struct
 {   // 5+1=6
     eObrd_version_t                     version;
     eObrd_canlocation_t                 canloc;
@@ -651,7 +657,7 @@ typedef struct
 {   // 1+3+324=328
     uint8_t                                 type;               // use eOmn_serv_type_t to identify what kind of service it is
     uint8_t                                 diagnosticsmode;    // use eOmn_serv_diagn_mode_t
-    uint16_t                                diagnosticsparam;
+    uint16_t                                diagnosticsparam;   // i cannot fit eOmn_serv_diagn_cfg_t inside here because of alignment and i want to keep backwards compatibility
     eOmn_serv_config_data_t                 data;   
 } eOmn_serv_configuration_t;                EO_VERIFYsizeof(eOmn_serv_configuration_t, 332) 
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -770,7 +770,7 @@ extern eOmn_serv_type_t eomn_string2servicetype(const char * string);
 
 extern const char * eomn_servicediagnmode2string(eOmn_serv_diagn_mode_t diagmode);
 
-extern eOmn_serv_diagn_mode_t eomn_string2serviceservicediagnmode(const char * string);
+extern eOmn_serv_diagn_mode_t eomn_string2servicediagnmode(const char * string);
 
 /** @}            
     end of group eo_management  

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -467,7 +467,15 @@ typedef enum
 
 enum { eomn_serv_types_numberof = 17 };
 
+typedef enum
+{
+    eOmn_serv_diagn_mode_NONE       = 0, // put in here for backwards compatibility ...
+    eOmn_serv_diagn_mode_UNKNOWN    = 1,
+    eOmn_serv_diagn_mode_MC_AMO     = 2,
+    eOmn_serv_diagn_mode_MC_ENC     = 3
+} eOmn_serv_diagn_mode_t;
 
+enum { eomn_serv_diagn_mode_numberof = 4 };
 
 typedef struct
 {   // 5+1=6
@@ -641,8 +649,9 @@ typedef union
 
 typedef struct                              
 {   // 1+3+324=328
-    uint8_t                                 type;           // use eOmn_serv_type_t to identify what kind of service it is
-    uint8_t                                 filler[3];
+    uint8_t                                 type;               // use eOmn_serv_type_t to identify what kind of service it is
+    uint8_t                                 diagnosticsmode;    // use eOmn_serv_diagn_mode_t
+    uint16_t                                diagnosticsparam;
     eOmn_serv_config_data_t                 data;   
 } eOmn_serv_configuration_t;                EO_VERIFYsizeof(eOmn_serv_configuration_t, 332) 
 
@@ -753,6 +762,9 @@ extern const char * eomn_servicetype2string(eOmn_serv_type_t service);
 extern eOmn_serv_type_t eomn_string2servicetype(const char * string);
 
 
+extern const char * eomn_servicediagnmode2string(eOmn_serv_diagn_mode_t diagmode);
+
+extern eOmn_serv_diagn_mode_t eomn_string2serviceservicediagnmode(const char * string);
 
 /** @}            
     end of group eo_management  

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 18 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 19 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };


### PR DESCRIPTION
## Description

This PR adds runtime configuration of additional diagnostics useful for debugging services on the robot. 

Runtime configuration means that yarprobotinterface collects some parameters from xml files and sends them to the ETH boards so that this one can use them to activate / tune some actions.

So far, only the AMO diagnostics in MC service is supported. 

## Details

See https://github.com/robotology/icub-firmware/pull/187
