### PR TITLE
AMO data to YARP ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.20.1)
+        VERSION 1.20.2)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.c
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.c
@@ -97,7 +97,8 @@ static const char * s_mn_servicediagnmode_strings[] =
     "eomn_serv_diagn_mode_NONE",
     "eomn_serv_diagn_mode_UNKNOWN",
     "eomn_serv_diagn_mode_MC_AMO",
-    "eomn_serv_diagn_mode_MC_ENC"
+    "eomn_serv_diagn_mode_MC_ENC",
+    "eomn_serv_diagn_mode_MC_AMOyarp"
 };  EO_VERIFYsizeof(s_mn_servicediagnmode_strings, eomn_serv_diagn_mode_numberof*sizeof(const char *))   
  
 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -472,10 +472,11 @@ typedef enum
     eomn_serv_diagn_mode_NONE       = 0, // put in here for backwards compatibility ...
     eomn_serv_diagn_mode_UNKNOWN    = 1,
     eomn_serv_diagn_mode_MC_AMO     = 2,
-    eomn_serv_diagn_mode_MC_ENC     = 3
+    eomn_serv_diagn_mode_MC_ENC     = 3,
+    eomn_serv_diagn_mode_MC_AMOyarp = 4
 } eOmn_serv_diagn_mode_t;
 
-enum { eomn_serv_diagn_mode_numberof = 4 };
+enum { eomn_serv_diagn_mode_numberof = 5 };
 
 typedef struct
 {

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -839,12 +839,13 @@ typedef struct              //size is = 12
 /** @typedef    typedef struct eOmc_joint_status_t
     @brief      eOmc_joint_status_t contains the status of a joint
  **/
-typedef struct                  // size is:  40+28+12 = 44
+typedef struct                  // size is:  40+28+12+16 = 96
 {
     eOmc_joint_status_core_t            core;
     eOmc_joint_status_target_t          target;
     eOmc_joint_status_additionalInfo_t  addinfo;
-} eOmc_joint_status_t;         EO_VERIFYsizeof(eOmc_joint_status_t, 80) 
+    uint8_t                             debug[16];
+} eOmc_joint_status_t;         EO_VERIFYsizeof(eOmc_joint_status_t, 96) 
 
 
 
@@ -865,13 +866,13 @@ typedef struct                  // size is 28+12+1+1+1+1+0 = 44
 /** @typedef    typedef struct eOmc_joint_t
     @brief      contains the whole joint
  **/
-typedef struct                  // size is 184+80+4+44+0 = 312
+typedef struct                  // size is 184+96+4+44+0 = 312
 {   
     eOmc_joint_config_t         config;                     /**< the configuration of the joint */
     eOmc_joint_status_t         status;                     /**< the status of the joint */
     eOmc_joint_inputs_t         inputs;                     /**< it contains all the values that a host can send to a joint as inputs */
     eOmc_joint_commands_t       cmmnds;                     /**< it contains all the commands that a host can send to a joint */
-} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 312);
+} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 328);
 
 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
@@ -87,16 +87,17 @@ typedef enum
     eoprot_tag_mc_joint_status_core_modes_interactionmodestatus     = 13,
     eoprot_tag_mc_joint_status_core_modes_ismotiondone              = 14,
     eoprot_tag_mc_joint_status_addinfo_multienc                     = 15,
-    eoprot_tag_mc_joint_inputs                                      = 16,
-    eoprot_tag_mc_joint_inputs_externallymeasuredtorque             = 17,
-    eoprot_tag_mc_joint_cmmnds_calibration                          = 18,
-    eoprot_tag_mc_joint_cmmnds_setpoint                             = 19,
-    eoprot_tag_mc_joint_cmmnds_stoptrajectory                       = 20,
-    eoprot_tag_mc_joint_cmmnds_controlmode                          = 21,
-    eoprot_tag_mc_joint_cmmnds_interactionmode                      = 22
+    eoprot_tag_mc_joint_status_debug                                = 16,
+    eoprot_tag_mc_joint_inputs                                      = 17,
+    eoprot_tag_mc_joint_inputs_externallymeasuredtorque             = 18,
+    eoprot_tag_mc_joint_cmmnds_calibration                          = 19,
+    eoprot_tag_mc_joint_cmmnds_setpoint                             = 20,
+    eoprot_tag_mc_joint_cmmnds_stoptrajectory                       = 21,
+    eoprot_tag_mc_joint_cmmnds_controlmode                          = 22,
+    eoprot_tag_mc_joint_cmmnds_interactionmode                      = 23
 } eOprot_tag_mc_joint_t;
 
-enum { eoprot_tags_mc_joint_numberof = 23 };  // it MUST be equal to the number of tags
+enum { eoprot_tags_mc_joint_numberof = 24 };  // it MUST be equal to the number of tags
 
 
 /** @typedef    typedef enum eOprot_rwm_mc_joint_t
@@ -122,6 +123,7 @@ typedef enum
     eoprot_rwm_mc_joint_status_core_modes_interactionmodestatus     = eo_nv_rwmode_RO,
     eoprot_rwm_mc_joint_status_core_modes_ismotiondone              = eo_nv_rwmode_RO,
     eoprot_rwm_mc_joint_status_addinfo_multienc                     = eo_nv_rwmode_RO,
+    eoprot_rwm_mc_joint_status_debug                                = eo_nv_rwmode_RO,
     eoprot_rwm_mc_joint_inputs                                      = eo_nv_rwmode_RW,
     eoprot_rwm_mc_joint_inputs_externallymeasuredtorque             = eo_nv_rwmode_RW,
     eoprot_rwm_mc_joint_cmmnds_calibration                          = eo_nv_rwmode_RW,
@@ -131,7 +133,7 @@ typedef enum
     eoprot_rwm_mc_joint_cmmnds_interactionmode                      = eo_nv_rwmode_RW
 } eOprot_rwm_mc_joint_t;    
 
-enum { eoprot_rwms_mc_joint_numberof = 23 };  // it MUST be equal to the number of rw modes  
+enum { eoprot_rwms_mc_joint_numberof = 24 };  // it MUST be equal to the number of rw modes  
 
 
 // - definition of the motor
@@ -298,6 +300,9 @@ extern void eoprot_fun_UPDT_mc_joint_status_core_modes_ismotiondone(const EOnv* 
 
 extern void eoprot_fun_INIT_mc_joint_status_addinfo_multienc(const EOnv* nv);
 extern void eoprot_fun_UPDT_mc_joint_status_addinfo_multienc(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_mc_joint_status_debug(const EOnv* nv);
+extern void eoprot_fun_UPDT_mc_joint_status_debug(const EOnv* nv, const eOropdescriptor_t* rd);
 
 extern void eoprot_fun_INIT_mc_joint_inputs(const EOnv* nv);
 extern void eoprot_fun_UPDT_mc_joint_inputs(const EOnv* nv, const eOropdescriptor_t* rd);

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 22 };
+enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 23 };
 
 enum { eoprot_entities_mc_numberof = eomc_entities_numberof };
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 19 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 20 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_fun.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_fun.c
@@ -244,6 +244,14 @@ EO_weak extern void eoprot_fun_INIT_mc_joint_status_addinfo_multienc(const EOnv*
 EO_weak extern void eoprot_fun_UPDT_mc_joint_status_addinfo_multienc(const EOnv* nv, const eOropdescriptor_t* rd) {}
 #endif 
     
+#if !defined(OVERRIDE_eoprot_fun_INIT_mc_joint_status_debug)
+EO_weak extern void eoprot_fun_INIT_mc_joint_status_debug(const EOnv* nv) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_UPDT_mc_joint_status_debug)
+EO_weak extern void eoprot_fun_UPDT_mc_joint_status_debug(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif     
+    
 #if !defined(OVERRIDE_eoprot_fun_INIT_mc_joint_inputs)
 EO_weak extern void eoprot_fun_INIT_mc_joint_inputs(const EOnv* nv) {}
 #endif

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_rom.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolMC_rom.c
@@ -378,6 +378,22 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_status_addinfo_mu
 };
 
 
+static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_status_debug =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.status.debug),
+    EO_INIT(.rwmode)    eoprot_rwm_mc_joint_status_debug,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_mc_rom_joint_defaultvalue.status.debug,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_mc_joint_status_debug,
+    EO_INIT(.update)    eoprot_fun_UPDT_mc_joint_status_debug
+#endif
+};
+
+
 static EOPROT_ROMmap EOnv_rom_t eoprot_mc_rom_descriptor_joint_inputs =
 {   
     EO_INIT(.capacity)  sizeof(eoprot_mc_rom_joint_defaultvalue.inputs),
@@ -715,6 +731,7 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_mc_rom_joint_descriptors[] =
     &eoprot_mc_rom_descriptor_joint_status_core_modes_interactionmodestatus,
     &eoprot_mc_rom_descriptor_joint_status_core_modes_ismotiondone,
     &eoprot_mc_rom_descriptor_joint_status_addinfo_multienc,
+    &eoprot_mc_rom_descriptor_joint_status_debug,
     &eoprot_mc_rom_descriptor_joint_inputs,
     &eoprot_mc_rom_descriptor_joint_inputs_externallymeasuredtorque,
     &eoprot_mc_rom_descriptor_joint_cmmnds_calibration,
@@ -811,6 +828,7 @@ static const char * const s_eoprot_mc_strings_tags_joint[] =
     "eoprot_tag_mc_joint_status_core_modes_interactionmodestatus",
     "eoprot_tag_mc_joint_status_core_modes_ismotiondone",
     "eoprot_tag_mc_joint_status_addinfo_multienc",
+    "eoprot_tag_mc_joint_status_debug",
     "eoprot_tag_mc_joint_inputs",
     "eoprot_tag_mc_joint_inputs_externallymeasuredtorque",
     "eoprot_tag_mc_joint_cmmnds_calibration",


### PR DESCRIPTION
## Description
This PR belongs to a set of PRs which enable to stream AMO data towards YARP ports.

See robotology/icub-firmware#188 for details.

## Requirements of this PR

To enable the features of this PR we also need similar PRs. They are:
- in [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared/pull/49) which contains the data structures,
-  in  [`icub-firmware`](https://github.com/robotology/icub-firmware/pull/188) we have the code for the ETH boards
- in [`icub-main`](https://github.com/robotology/icub-main/pull/753) which contains code to publish on the YARP port.
- in [`icub-firmware-build`](https://github.com/robotology/icub-firmware-build/pull/30) to give the new binaries for the `ems`, `mc4plus`, `mc2plus`.
