### PR TITLE
add support for aea3 encoder

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -83,6 +83,7 @@ static const eOmap_str_str_u08_t s_eomc_map_of_actuators[] =
 static const eOmap_str_str_u08_t s_eomc_map_of_encoders[] =
 {    
     {"aea", "eomc_enc_aea",eomc_enc_aea},
+    {"aea3", "eomc_enc_aea3", eomc_enc_aea3},
     {"roie", "eomc_enc_roie",eomc_enc_roie},
     {"absanalog", "eomc_enc_absanalog", eomc_enc_absanalog},    
     {"mais", "eomc_enc_mais", eomc_enc_mais},
@@ -267,6 +268,7 @@ extern uint8_t eomc_encoder_get_numberofcomponents(eOmc_encoder_t encoder)
     switch(encoder)
     {        
         case eomc_enc_aea:
+        case eomc_enc_aea3:
         case eomc_enc_roie:
         case eomc_enc_absanalog:
         case eomc_enc_mais:    

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -1096,12 +1096,13 @@ typedef enum
     eomc_enc_amo            = 9, 
     eomc_enc_psc            = 10,
     eomc_enc_pos            = 11,
+    eomc_enc_aea3           = 12,
     
     eomc_enc_none           = 0,
     eomc_enc_unknown        = 255    
 } eOmc_encoder_t;
 
-enum { eomc_encoders_numberof = 11 };
+enum { eomc_encoders_numberof = 12 };
 enum { eomc_encoders_maxnumberofcomponents = 4 };
 
 


### PR DESCRIPTION
This PR adds the support for aea3 encoder.

In particular, it adds a new value `eomc_enc_aea3` in the enum type `eOmc_encoder_t` which is needed by these PRs on [`icub-firmware`](https://github.com/robotology/icub-firmware-shared/pull/50) and[ `icub-main`](https://github.com/robotology/icub-main/pull/769) to support the new sensors.

This change is backwards compatible with both repositories, so we can safely merge this PR before the other two.
