### PR TITLE
Basic support for board amcbldc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.22.0)
+        VERSION 1.22.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/can/canProtocolLib/iCubCanProto_types.h
+++ b/can/canProtocolLib/iCubCanProto_types.h
@@ -75,6 +75,7 @@ extern "C" {
 #define ICUBCANPROTO_BOARDTYPE__PSC     15
 #define ICUBCANPROTO_BOARDTYPE__MTB4W   16
 #define ICUBCANPROTO_BOARDTYPE__PMC     17
+#define ICUBCANPROTO_BOARDTYPE__AMCBLDC 18
 #define ICUBCANPROTO_BOARDTYPE__UNKNOWN 255
 
 // skin types
@@ -109,6 +110,7 @@ typedef enum
     icubCanProto_boardType__psc     = ICUBCANPROTO_BOARDTYPE__PSC,
     icubCanProto_boardType__mtb4w   = ICUBCANPROTO_BOARDTYPE__MTB4W,
     icubCanProto_boardType__pmc     = ICUBCANPROTO_BOARDTYPE__PMC,
+    icubCanProto_boardType__amcbldc = ICUBCANPROTO_BOARDTYPE__AMCBLDC,
     icubCanProto_boardType__unknown = ICUBCANPROTO_BOARDTYPE__UNKNOWN
 } icubCanProto_boardType_t;
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -118,7 +118,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"psc", "eobrd_psc", eobrd_psc},
     {"mtb4w", "eobrd_mtb4w", eobrd_mtb4w},
     {"pmc", "eobrd_pmc", eobrd_pmc},
-    {"amcbldc", "eobrd_amcbldc", eobrd_pmc},
+    {"amcbldc", "eobrd_amcbldc", eobrd_amcbldc},
     
     {"none", "eobrd_none", eobrd_none},
     {"unknown", "eobrd_unknown", eobrd_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -89,7 +89,8 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_sg3) |
                                                 (0x1LL << eobrd_psc) |
                                                 (0x1LL << eobrd_mtb4w) |
-                                                (0x1LL << eobrd_pmc);
+                                                (0x1LL << eobrd_pmc)   |
+                                                (0x1LL << eobrd_amcbldc);
        
    
 static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
@@ -117,6 +118,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"psc", "eobrd_psc", eobrd_psc},
     {"mtb4w", "eobrd_mtb4w", eobrd_mtb4w},
     {"pmc", "eobrd_pmc", eobrd_pmc},
+    {"amcbldc", "eobrd_amcbldc", eobrd_pmc},
     
     {"none", "eobrd_none", eobrd_none},
     {"unknown", "eobrd_unknown", eobrd_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -75,12 +75,12 @@ typedef enum
     eobrd_cantype_psc               = ICUBCANPROTO_BOARDTYPE__PSC,      // 15 (psc = proximal sensor collector)
     eobrd_cantype_mtb4w             = ICUBCANPROTO_BOARDTYPE__MTB4W,    // 16 (mtb4 for waseda university)
     eobrd_cantype_pmc               = ICUBCANPROTO_BOARDTYPE__PMC,      // 17 (pmc = piezo motor control)
-    
+    eobrd_cantype_amcbldc           = ICUBCANPROTO_BOARDTYPE__AMCBLDC,  // 18 (amcbldc)
     eobrd_cantype_none              = 254, 	
     eobrd_cantype_unknown           = ICUBCANPROTO_BOARDTYPE__UNKNOWN   // 255 
 } eObrd_cantype_t;
 
-enum { eobrd_cantype_numberof = 18 };
+enum { eobrd_cantype_numberof = 19 };
 
 
 typedef enum
@@ -125,12 +125,13 @@ typedef enum
     eobrd_psc                   = eobrd_cantype_psc,
     eobrd_mtb4w                 = eobrd_cantype_mtb4w,
     eobrd_pmc                   = eobrd_cantype_pmc,
+    eobrd_amcbldc               = eobrd_cantype_amcbldc,
 
     eobrd_none                  = 254,                      
     eobrd_unknown               = 255  // = ICUBCANPROTO_BOARDTYPE__UNKNOWN                     
 } eObrd_type_t;
 
-enum { eobrd_type_numberof = 21 };
+enum { eobrd_type_numberof = 22 };
 
 
 typedef struct                  


### PR DESCRIPTION
This PR allows the `FirmwareUpdater` in `icub-main` to recognize the board `amcbldc` for its operativity. 
In particular, with this [PR](https://github.com/robotology/icub-main/pull/778), the program `FirmwareUpdater` will be able to use the enum value dedicated to the `amcbldc`.

This change is small in size, but required also a change in the VERSION of icub_firmware_shared (from 1.22.0 to 1.22.1) in order to force icub-main to use it. 

