### PR TITLE
Add latest fault state to motor status data structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.22.1)
+        VERSION 1.22.2)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -804,7 +804,7 @@ typedef struct                  //size is 1+1+1+1 = 4
     eOenum08_t                  controlmodestatus;          /**< use eOmc_controlmode_t. */
     eOenum08_t                  interactionmodestatus;      /**< use values from eOmc_interactionmode_t */
     eObool_t                    ismotiondone;               /**< simply eobool_true or eobool_false */                      
-    uint8_t                     fault_state;
+    uint8_t                     fault_state_mask;
 } eOmc_joint_status_modes_t;
 
 
@@ -956,7 +956,7 @@ typedef struct                  // size is: 4+4+4+2+2+2+2 = 20
 typedef struct                  // size is: 20+4+0 = 24
 {   
     eOmc_motor_status_basic_t   basic;                  /**< the basic status of a motor */   
-    uint32_t                    mc_fault_state;            /**< represents the motion controller fault state */   
+    uint32_t                    fault_state_mask;            /**< represents the motion controller fault state */   
 } eOmc_motor_status_t;          EO_VERIFYsizeof(eOmc_motor_status_t, 24)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -223,6 +223,16 @@ typedef enum
 } eOmc_calibration_type_t;
 
 
+/** @typedef    typedef enum eOmc_faultmode_t
+    @brief      contains the possible fault modes for a joint. 
+ **/
+typedef enum
+{
+    eomc_fault_none = 0,
+    eomc_fault_first = 1,
+    eomc_fault_last = 2
+} eOmc_faultmode_t;
+enum { eomc_fault_numbersof = 3 };
 
 // -- all the possible data service structures
 
@@ -794,7 +804,7 @@ typedef struct                  //size is 1+1+1+1 = 4
     eOenum08_t                  controlmodestatus;          /**< use eOmc_controlmode_t. */
     eOenum08_t                  interactionmodestatus;      /**< use values from eOmc_interactionmode_t */
     eObool_t                    ismotiondone;               /**< simply eobool_true or eobool_false */                      
-    uint8_t                     filler[1];    
+    uint8_t                     filler[1];
 } eOmc_joint_status_modes_t;
 
 
@@ -946,7 +956,7 @@ typedef struct                  // size is: 4+4+4+2+2+2+2 = 20
 typedef struct                  // size is: 20+4+0 = 24
 {   
     eOmc_motor_status_basic_t   basic;                  /**< the basic status of a motor */   
-    uint8_t                     filler[4];    
+    uint32_t                    fault_state_mask;       /**< bit mask where each bit represent a motor fault state */   
 } eOmc_motor_status_t;          EO_VERIFYsizeof(eOmc_motor_status_t, 24)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -804,7 +804,7 @@ typedef struct                  //size is 1+1+1+1 = 4
     eOenum08_t                  controlmodestatus;          /**< use eOmc_controlmode_t. */
     eOenum08_t                  interactionmodestatus;      /**< use values from eOmc_interactionmode_t */
     eObool_t                    ismotiondone;               /**< simply eobool_true or eobool_false */                      
-    uint8_t                     fault_state_mask;
+    uint8_t                     filler[1];
 } eOmc_joint_status_modes_t;
 
 
@@ -955,8 +955,8 @@ typedef struct                  // size is: 4+4+4+2+2+2+2 = 20
  **/
 typedef struct                  // size is: 20+4+0 = 24
 {   
-    eOmc_motor_status_basic_t   basic;                  /**< the basic status of a motor */   
-    uint32_t                    fault_state_mask;            /**< represents the motion controller fault state */   
+    eOmc_motor_status_basic_t   basic;                        /**< the basic status of a motor */   
+    uint32_t                    mc_fault_state;               /**< represents the most recent motion controller fault state */   
 } eOmc_motor_status_t;          EO_VERIFYsizeof(eOmc_motor_status_t, 24)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -804,7 +804,7 @@ typedef struct                  //size is 1+1+1+1 = 4
     eOenum08_t                  controlmodestatus;          /**< use eOmc_controlmode_t. */
     eOenum08_t                  interactionmodestatus;      /**< use values from eOmc_interactionmode_t */
     eObool_t                    ismotiondone;               /**< simply eobool_true or eobool_false */                      
-    uint8_t                     filler[1];
+    uint8_t                     fault_state;
 } eOmc_joint_status_modes_t;
 
 
@@ -956,7 +956,7 @@ typedef struct                  // size is: 4+4+4+2+2+2+2 = 20
 typedef struct                  // size is: 20+4+0 = 24
 {   
     eOmc_motor_status_basic_t   basic;                  /**< the basic status of a motor */   
-    uint32_t                    fault_state_mask;       /**< bit mask where each bit represent a motor fault state */   
+    uint32_t                    mc_fault_state;            /**< represents the motion controller fault state */   
 } eOmc_motor_status_t;          EO_VERIFYsizeof(eOmc_motor_status_t, 24)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -222,18 +222,6 @@ typedef enum
     eomc_calibration_typeUndefined                  = 255   // cannot change
 } eOmc_calibration_type_t;
 
-
-/** @typedef    typedef enum eOmc_faultmode_t
-    @brief      contains the possible fault modes for a joint. 
- **/
-typedef enum
-{
-    eomc_fault_none = 0,
-    eomc_fault_first = 1,
-    eomc_fault_last = 2
-} eOmc_faultmode_t;
-enum { eomc_fault_numbersof = 3 };
-
 // -- all the possible data service structures
 
 


### PR DESCRIPTION
This PR aims to complement the work done to address: https://github.com/robotology/community/discussions/561 , in which the feature request involved communicating the latest fault to the `yarpmotorgui`. To address it, the free space in the `motor_status_t` struct is filled with the error code associated to the most recent fault occurred on the joint, related to the category "motion controller". The data is retrieved by `embObjMotionControl` upon periodical request of the `yarpmotorgui`.

The fault states that can be communicated are the following:
```
  {eoerror_value_MC_motor_external_fault,  "MC: exernal fault button pressed."},
    {eoerror_value_MC_motor_overcurrent,     "MC: overcurrent. The motor has been turned off to prevent it from being damaged by an impulsive spike of current. par16 = ID of joint."},
    {eoerror_value_MC_motor_i2t_limit,       "MC: i2t limit exceeded. The motor has been turned off to prevent it from being damaged by overheating due to a continuous high current. par16 = ID of joint."},
    {eoerror_value_MC_motor_hallsensors,     "MC: 2FOC hall sensors fault. Invalid sequence in motor Hall effect sensors, please check motor hall cable connections. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_invalid_prot,"MC: 2FOC CAN invalid protocol. The EMS and 2FOC firmware versions are incompatible, please update. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_generic,     "MC: 2FOC CAN generic error. Errors happened in the CAN bus between the EMS and the 2FOC board. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_no_answer,   "MC: 2FOC CAN no answer. The communication between the EMS and the 2FOC board has been lost for more than 50 ms. par16 = ID of joint."},
    {eoerror_value_MC_axis_torque_sens,      "MC: torque sensor timeout. The joint is in a compliant interaction mode or torque control mode, and data from torque sensor have been unavailable for more than 100 ms. par16 = ID of joint."},
    {eoerror_value_MC_aea_abs_enc_invalid,   "MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_aea_abs_enc_timeout,   "MC: AEA encoder timeout. No answer from the magnetic position sensor of the joint (cable broken?). par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_aea_abs_enc_spikes,    "MC: AEA encoder has spikes. There is impulsive noise in the measures of the magnetic position sensor of the joint. par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_motor_qencoder_dirty,  "MC: 2FOC quadrature encoder dirty. The number of thicks in a complete revolution of the motor was lower than expected, the optical disks need to be cleaned. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_index,  "MC: 2FOC quadrature encoder index broken. The reference special thick was not detected during a complete revolution of the motor, please check motor encoder cables. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_phase,  "MC: 2FOC quadrature encoder phase broken. The motor encoder is not counting even if the motor is moving, please check motor encoder cables. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_generic_error,         "MC: generic motor error (see 64 bit mask parameter)."},
    {eoerror_value_MC_motor_wrong_state,     "MC: 2FOC wrong state. The 2FOC motor controller is in a control state different from required by the EMS. In par64 0xF0 is the mask of requested state, 0x0F is the mask of actual state. par16 = ID of joint."},
    {eoerror_value_MC_joint_hard_limit,      "MC: hard limit reached. The joint position is outside its hardware boundaries. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_phase_disappeared, "MC: qenc error has disappeared, warning counter has been reset."}
```
which belong to the `motion controller` category. 

Here below is a little demo of the `yarpmotorgui` displaying a hardware limit fault:

https://user-images.githubusercontent.com/38140169/145057677-9b9af4e4-94ae-497c-a74e-dec12718574f.mp4

Related PRs:
icub-firmware: https://github.com/robotology/icub-firmware/pull/224
icub-main: https://github.com/robotology/icub-main/pull/779