### PR TITLE
Further changes to embot::core::Data 

### DIFF
--- a/embot/core/embot_core.h
+++ b/embot/core/embot_core.h
@@ -127,7 +127,6 @@ namespace embot { namespace core {
         size_t capacity {0};
         
         constexpr Data() = default;
-        constexpr Data(void *p, size_t s) : pointer(p), capacity(s) {} 
         constexpr Data(const void *p, size_t s) : pointer(const_cast<void*>(p)), capacity(s) {} 
                     
         void load(void *littleendianmemory, const size_t s) { pointer = littleendianmemory; capacity = s; }
@@ -158,6 +157,8 @@ namespace embot { namespace core {
            std::memmove(pointer, other.pointer, n);
            return n;
         }
+        
+        std::uint8_t * getU08ptr() const { return reinterpret_cast<std::uint8_t*>(pointer); }
     };    
 
     


### PR DESCRIPTION
Sadly the previous [PR](https://github.com/robotology/icub-firmware-shared/pull/53) was not that backwards compatible so I am in here:
- adding back the method `std::uint8_t * getU08ptr() const` which is required by some `embot` object and 
- removing the  `Data(void *p, size_t s)` ctor which makes confusion w/ `constexpr Data(const void *p, size_t s)`.