### PR TITLE
FT service with multiple sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.24.0)
+        VERSION 1.24.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/core/core/EoCommon.h
+++ b/eth/embobj/core/core/EoCommon.h
@@ -174,6 +174,14 @@ typedef uint32_t    eOreltime_t;
 typedef uint64_t    eOabstime_t; 
 
 
+/** @typedef    typedef uint32_t eOabstime_ms_t
+    @brief      eOabstime_ms_t contains the time expressed in milli-seconds in a much longer range. It can be used
+                instead of eOabstime_t when we want to save memory (4B vs 8B) but ... at a lower resolution (ms vs us) 
+                at a lower duration (4294967 sec ~= 49 days)
+ **/
+typedef uint32_t    eOabstime_ms_t; 
+
+
 /** @typedef    typedef struct eOnanotime_t
     @brief      eOnanotime_t contains the time expressed at its finest resolution: nanoseconds.
                 It is used for both relative and absolute time when a finer resultion is needed.

--- a/eth/embobj/core/core/EoCommon.h
+++ b/eth/embobj/core/core/EoCommon.h
@@ -477,6 +477,7 @@ typedef     eObool_t    (*eObool_fp_uint32_t)                       (uint32_t);
 typedef     double      (*eOdouble_fp_void_t)                       (void);
 typedef     int8_t      (*eOint8_fp_voidp_uint32_t)                 (void*, uint32_t);
 typedef     int8_t      (*eOint8_fp_voidp)                          (void*);
+typedef     int         (*eOint_fp_constcharp)                      (const char*);
 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -87,7 +87,8 @@ static const char * s_eoas_sensors_strings[] =
     "eoas_imu_status",
     "eoas_temperature",
     "eoas_psc_angle",
-    "eoas_pos_angle"
+    "eoas_pos_angle",
+    "eoas_ft"
 };  EO_VERIFYsizeof(s_eoas_sensors_strings, eoas_sensors_numberof*sizeof(const char *));    
 
 
@@ -421,6 +422,39 @@ extern const eObrd_info_t * eoas_temperature_setof_boardinfos_find(const eOas_te
     return r;
 }
 
+
+// 
+
+static const eObrd_cantype_t s_eoas_ft_supportedboards_types[] = { eobrd_cantype_strain, eobrd_cantype_strain2 };
+
+
+extern uint8_t eoas_ft_supportedboards_numberof(void)
+{
+    return sizeof(s_eoas_ft_supportedboards_types)/sizeof(eObrd_cantype_t);
+}
+
+extern eObrd_cantype_t eoas_ft_supportedboards_gettype(uint8_t pos)
+{
+    if(pos >= eoas_ft_supportedboards_numberof())
+    {
+        return eobrd_cantype_none;
+    }
+    
+    return s_eoas_ft_supportedboards_types[pos];    
+}
+
+extern eObool_t eoas_ft_isboardvalid(eObrd_cantype_t boardtype)
+{
+    for(uint8_t n=0; n<eoas_ft_supportedboards_numberof(); n++)
+    {
+        if(s_eoas_ft_supportedboards_types == boardtype)
+        {
+            return eobool_true;
+        }
+    }
+    
+    return eobool_false;    
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of extern hidden functions 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -447,7 +447,7 @@ extern eObool_t eoas_ft_isboardvalid(eObrd_cantype_t boardtype)
 {
     for(uint8_t n=0; n<eoas_ft_supportedboards_numberof(); n++)
     {
-        if(s_eoas_ft_supportedboards_types == boardtype)
+        if(boardtype == s_eoas_ft_supportedboards_types[n])
         {
             return eobool_true;
         }

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -704,10 +704,10 @@ enum { eoas_ft_6axis = 6 };
 
 typedef struct
 {
-    eOenum08_t              mode;           // use eOas_ft_mode_t                                 
-    uint8_t                 ftdatarate;     // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
-    uint8_t                 calibrationset; // can be calibration set 0, 1, 2
-    uint8_t                 tempdatarate;   // in seconds 
+    eOenum08_t              mode;               // use eOas_ft_mode_t                                 
+    uint8_t                 ftperiod;           // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
+    uint8_t                 calibrationset;     // can be calibration set 0, 1, 2
+    uint8_t                 temperatureperiod;  // in seconds 
 } eOas_ft_config_t;         EO_VERIFYsizeof(eOas_ft_config_t, 4)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -705,9 +705,9 @@ enum { eoas_ft_6axis = 6 };
 typedef struct
 {
     eOenum08_t              mode;           // use eOas_ft_mode_t                                 
-    uint8_t                 datarate;       // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
+    uint8_t                 ftdatarate;     // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
     uint8_t                 calibrationset; // can be calibration set 0, 1, 2
-    uint8_t                 filler01[1];    // maybe in future sepcifies unit time for datarate (0 -> ms, 1 -> 100 us, 2 -> 10 ms, 3 -> 100 ms) 
+    uint8_t                 tempdatarate;   // in seconds 
 } eOas_ft_config_t;         EO_VERIFYsizeof(eOas_ft_config_t, 4)
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -215,6 +215,18 @@ static const eOmap_str_str_u08_t s_boards_map_of_portposs[] =
 };  EO_VERIFYsizeof(s_boards_map_of_portposs, (eobrd_portposs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
+static const eOmap_str_str_u08_t s_boards_map_of_reportmodes[] =
+{
+    {"NEVER", "eobrd_canmonitor_reportmode_NEVER", eobrd_canmonitor_reportmode_NEVER},
+    {"justLOSTjustFOUND", "eobrd_canmonitor_reportmode_justLOSTjustFOUND", eobrd_canmonitor_reportmode_justLOSTjustFOUND},
+    {"justLOSTjustFOUNDstillLOST", "eobrd_canmonitor_reportmode_justLOSTjustFOUNDstillLOST", eobrd_canmonitor_reportmode_justLOSTjustFOUNDstillLOST},
+    {"ALL", "eobrd_canmonitor_reportmode_ALL", eobrd_canmonitor_reportmode_ALL},
+
+    {"none", "eobrd_canmonitor_reportmode_none", eobrd_canmonitor_reportmode_none},
+    {"unknown", "eobrd_canmonitor_reportmode_unknown", eobrd_canmonitor_reportmode_unknown}    
+};  EO_VERIFYsizeof(s_boards_map_of_reportmodes, (eobrd_reportmodes_numberof+2)*sizeof(eOmap_str_str_u08_t))
+
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
 // --------------------------------------------------------------------------------------------------------------------
@@ -550,6 +562,31 @@ extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t use
     const uint8_t defvalue = eobrd_portpos_unknown;
     
     return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+}
+
+extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mode, eObool_t usecompactstring)
+{
+    const eOmap_str_str_u08_t * map = s_boards_map_of_reportmodes;
+    const uint8_t size = eobrd_reportmodes_numberof+2;
+    const uint8_t value = mode;
+    const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
+    
+    if(NULL == str)
+    {
+        str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
+    }
+    
+    return(str);   
+}
+
+
+extern eObrd_canmonitor_reportmode_t eoboards_string2reportmode(const char * string, eObool_t usecompactstring)
+{
+    const eOmap_str_str_u08_t * map = s_boards_map_of_reportmodes;
+    const uint8_t size = eobrd_portposs_numberof+2;
+    const uint8_t defvalue = eobrd_portpos_unknown;
+    
+    return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -382,8 +382,8 @@ enum { eobrd_reportmodes_numberof = 4 };
 
 typedef struct
 {
-    uint8_t         mode;               // use eObrd_canmonitor_reportmode_t
     uint8_t         checkrate;          // in ms: rate of check of presence of the boards. if 0 we dont do any check
+    uint8_t         reportmode;         // use eObrd_canmonitor_reportmode_t
     uint16_t        periodicreportrate; // in ms: rate of reporting of presence or absence. if 0 we dont do any periodic report
 } eObrd_canmonitor_cfg_t; EO_VERIFYsizeof(eObrd_canmonitor_cfg_t, 4) 
     

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -382,9 +382,9 @@ enum { eobrd_reportmodes_numberof = 4 };
 
 typedef struct
 {
-    uint8_t         checkrate;          // in ms: rate of check of presence of the boards. if 0 we dont do any check
+    uint8_t         periodofcheck;      // in ms: period of check of presence of the boards. if 0 we dont do any check
     uint8_t         reportmode;         // use eObrd_canmonitor_reportmode_t
-    uint16_t        periodicreportrate; // in ms: rate of reporting of presence or absence. if 0 we dont do any periodic report
+    uint16_t        periodofreport;     // in ms: period of reporting of presence or absence. if 0 we dont do any periodic report
 } eObrd_canmonitor_cfg_t; EO_VERIFYsizeof(eObrd_canmonitor_cfg_t, 4) 
     
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -366,6 +366,26 @@ typedef enum
 } eObrd_portpos_t;
 
 enum { eobrd_portposs_numberof = 7 };
+
+
+typedef enum
+{
+    eobrd_canmonitor_reportmode_NEVER       = 0, // we never report
+    eobrd_canmonitor_reportmode_justLOSTjustFOUND = 1, // report only once if boards disappears (or reappers)
+    eobrd_canmonitor_reportmode_justLOSTjustFOUNDstillLOST = 2,
+    eobrd_canmonitor_reportmode_ALL         = 3, // report changes but also period state (all present or still missing) 
+    eobrd_canmonitor_reportmode_none        = 31,    
+    eobrd_canmonitor_reportmode_unknown     = 30    
+} eObrd_canmonitor_reportmode_t;
+
+enum { eobrd_reportmodes_numberof = 4 };
+
+typedef struct
+{
+    uint8_t         mode;               // use eObrd_canmonitor_reportmode_t
+    uint8_t         checkrate;          // in ms: rate of check of presence of the boards. if 0 we dont do any check
+    uint16_t        periodicreportrate; // in ms: rate of reporting of presence or absence. if 0 we dont do any periodic report
+} eObrd_canmonitor_cfg_t; EO_VERIFYsizeof(eObrd_canmonitor_cfg_t, 4) 
     
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------
 // empty-section
@@ -409,7 +429,9 @@ extern eObrd_portpsc_t eoboards_string2portpsc(const char * string, eObool_t use
 extern const char * eoboards_portpos2string(eObrd_portpos_t portpos, eObool_t usecompactstring);
 extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t usecompactstring);
 
-    
+extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mode, eObool_t usecompactstring);
+extern eObrd_canmonitor_reportmode_t eoboards_string2reportmode(const char * string, eObool_t usecompactstring);
+
 /** @}            
     end of group eo_cevcwervcrev5555  
  **/

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -158,11 +158,13 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_canservices_board_wrongprotversion, "SYS: the board on the specified CAN bus / adr has incompatible fw protocol version. In par16 there is required prot, in par64 there is detected type, fw and prot version."},
     {eoerror_value_SYS_canservices_board_notfound, "SYS: the board on the specified CAN bus / adr was not found during the discovery phase. In par16 there is the board type"},
     {eoerror_value_SYS_transceiver_rxinvalidframe_error, "SYS: the board has detected an invalid ropframe in reception."},
-    {eoerror_value_SYS_canservices_boards_regularcontact, "SYS: a service has verified that the TX of its CAN boards is regular. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of boards (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
-    {eoerror_value_SYS_canservices_boards_lostcontact,  "SYS: a service has detected that some CAN boards have stopped transmission. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
-    {eoerror_value_SYS_canservices_boards_stillnocontact,  "SYS: a service has detected that some CAN boards are still not transmitting. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
-    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered all CAN boards that were not transmitting. In sourceaddress the eOmn_serv_category_t)"},
-    {eoerror_value_SYS_bootstrapping, "SYS: the board is bootstrapping"}
+    {eoerror_value_SYS_canservices_boards_lostcontact, "SYS: a service has detected that some CAN boards are not broacasting anymore. In par16 the type of service, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
+    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered some CAN boards that were not broacasting anymore. In par16 the type of service)"},
+    {eoerror_value_SYS_bootstrapping, "SYS: the board is bootstrapping"},
+    {eoerror_value_SYS_canservices_monitor_regularcontact, "SYS: a service has verified that the TX of its CAN boards is regular. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of boards (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
+    {eoerror_value_SYS_canservices_monitor_lostcontact,  "SYS: a service has detected that some CAN boards have stopped transmission. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits), in in par64 MS 32 bits the time in ms since last contact"},
+    {eoerror_value_SYS_canservices_monitor_stillnocontact,  "SYS: a service has detected that some CAN boards are still not transmitting. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits), in in par64 MS 32 bits the total disappearence time in ms"},
+    {eoerror_value_SYS_canservices_monitor_retrievedcontact, "SYS: a service has recovered all CAN boards that were not transmitting. In sourceaddress the eOmn_serv_category_t)"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -158,8 +158,10 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_canservices_board_wrongprotversion, "SYS: the board on the specified CAN bus / adr has incompatible fw protocol version. In par16 there is required prot, in par64 there is detected type, fw and prot version."},
     {eoerror_value_SYS_canservices_board_notfound, "SYS: the board on the specified CAN bus / adr was not found during the discovery phase. In par16 there is the board type"},
     {eoerror_value_SYS_transceiver_rxinvalidframe_error, "SYS: the board has detected an invalid ropframe in reception."},
-    {eoerror_value_SYS_canservices_boards_lostcontact, "SYS: a service has detected that some CAN boards are not broacasting anymore. In par16 the type of boards, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
-    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered some CAN boards that were not broacasting anymore. In par16 the type of boards)"},
+    {eoerror_value_SYS_canservices_boards_regularcontact, "SYS: a service has verified that the TX of its CAN boards is regular. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of boards (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
+    {eoerror_value_SYS_canservices_boards_lostcontact,  "SYS: a service has detected that some CAN boards have stopped transmission. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
+    {eoerror_value_SYS_canservices_boards_stillnocontact,  "SYS: a service has detected that some CAN boards are still not transmitting. In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits)"},
+    {eoerror_value_SYS_canservices_boards_retrievedcontact, "SYS: a service has recovered all CAN boards that were not transmitting. In sourceaddress the eOmn_serv_category_t)"},
     {eoerror_value_SYS_bootstrapping, "SYS: the board is bootstrapping"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -334,8 +334,15 @@ const eoerror_valuestring_t eoerror_valuestrings_CFG[] =
  
     {eoerror_value_CFG_mc_mc4pluspmc_ok, "CFG: EOtheMotionController can correctly configure mc4pluspmc-based motion. more info will follow"},
     {eoerror_value_CFG_mc_mc4pluspmc_failed_encoders_verify, "CFG: EOtheMotionController cannot be configured. verification of encoder fails for mc4pluspmc. see other messages for more details"},
-    {eoerror_value_CFG_mc_mc4pluspmc_failed_candiscovery_of_pmc, "CFG: EOtheMotionController cannot be configured. verification of pos for mc4pluspmc fails. see other messages for more details"}    
+    {eoerror_value_CFG_mc_mc4pluspmc_failed_candiscovery_of_pmc, "CFG: EOtheMotionController cannot be configured. verification of pos for mc4pluspmc fails. see other messages for more details"},    
 
+    {eoerror_value_CFG_ft_ok, "CFG: theFTservice is OK"},
+    {eoerror_value_CFG_ft_failed_candiscovery, "CFG: theFTservice failed CAN discovery"},
+    {eoerror_value_CFG_ft_not_verified_yet, "CFG: theFTservice is not verified yet"},
+    {eoerror_value_CFG_ft_using_onboard_config, "CFG: theFTservice is using onboard config"},
+    {eoerror_value_CFG_ft_failed_notsupported, "CFG: theFTservice is not supported"},
+    {eoerror_value_CFG_ft_failed_fullscales, "CFG: theFTservice cannot get fullscales"}
+        
 };  EO_VERIFYsizeof(eoerror_valuestrings_CFG, eoerror_value_CFG_numberof*sizeof(const eoerror_valuestring_t))
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -171,12 +171,15 @@ typedef enum
     eoerror_value_SYS_canservices_board_wrongprotversion    = 54,
     eoerror_value_SYS_canservices_board_notfound            = 55,
     eoerror_value_SYS_transceiver_rxinvalidframe_error      = 56,
-    eoerror_value_SYS_canservices_boards_lostcontact        = 57,
-    eoerror_value_SYS_canservices_boards_retrievedcontact   = 58,
-    eoerror_value_SYS_bootstrapping                         = 59
+    eoerror_value_SYS_canservices_boards_regularcontact     = 57,
+    eoerror_value_SYS_canservices_boards_lostcontact        = 58,
+    eoerror_value_SYS_canservices_boards_stillnocontact     = 59,
+    eoerror_value_SYS_canservices_boards_retrievedcontact   = 60,
+    eoerror_value_SYS_bootstrapping                         = 61,
+    
 } eOerror_value_SYS_t;
 
-enum { eoerror_value_SYS_numberof = 60 };
+enum { eoerror_value_SYS_numberof = 62 };
 
 
 /** @typedef    typedef enum eOerror_value_HW_t

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -386,11 +386,18 @@ typedef enum
 
     eoerror_value_CFG_mc_mc4pluspmc_ok                 = 87,
     eoerror_value_CFG_mc_mc4pluspmc_failed_encoders_verify = 88, 
-    eoerror_value_CFG_mc_mc4pluspmc_failed_candiscovery_of_pmc = 89,  
+    eoerror_value_CFG_mc_mc4pluspmc_failed_candiscovery_of_pmc = 89, 
+
+    eoerror_value_CFG_ft_ok                             = 90,
+    eoerror_value_CFG_ft_failed_candiscovery            = 91,
+    eoerror_value_CFG_ft_not_verified_yet               = 92,
+    eoerror_value_CFG_ft_using_onboard_config           = 93,
+    eoerror_value_CFG_ft_failed_notsupported            = 94,
+    eoerror_value_CFG_ft_failed_fullscales              = 95
     
 } eOerror_value_CFG_t;
 
-enum { eoerror_value_CFG_numberof = 90 };
+enum { eoerror_value_CFG_numberof = 96 };
 
 
 /** @typedef    typedef enum eOerror_value_ETHMON_t

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -171,15 +171,17 @@ typedef enum
     eoerror_value_SYS_canservices_board_wrongprotversion    = 54,
     eoerror_value_SYS_canservices_board_notfound            = 55,
     eoerror_value_SYS_transceiver_rxinvalidframe_error      = 56,
-    eoerror_value_SYS_canservices_boards_regularcontact     = 57,
-    eoerror_value_SYS_canservices_boards_lostcontact        = 58,
-    eoerror_value_SYS_canservices_boards_stillnocontact     = 59,
-    eoerror_value_SYS_canservices_boards_retrievedcontact   = 60,
-    eoerror_value_SYS_bootstrapping                         = 61,
+    eoerror_value_SYS_canservices_boards_lostcontact        = 57,
+    eoerror_value_SYS_canservices_boards_retrievedcontact   = 58,
+    eoerror_value_SYS_bootstrapping                         = 59,    
+    eoerror_value_SYS_canservices_monitor_regularcontact    = 60,
+    eoerror_value_SYS_canservices_monitor_lostcontact       = 61,
+    eoerror_value_SYS_canservices_monitor_stillnocontact    = 62,
+    eoerror_value_SYS_canservices_monitor_retrievedcontact  = 63
     
 } eOerror_value_SYS_t;
 
-enum { eoerror_value_SYS_numberof = 62 };
+enum { eoerror_value_SYS_numberof = 64 };
 
 
 /** @typedef    typedef enum eOerror_value_HW_t

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.c
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.c
@@ -85,7 +85,8 @@ static const char * s_mn_servicetype_strings[] =
     "eomn_serv_AS_psc",
     "eomn_serv_AS_pos",
     "eomn_serv_MC_mc4plusfaps",
-    "eomn_serv_MC_mc4pluspmc"
+    "eomn_serv_MC_mc4pluspmc",
+    "eomn_serv_AS_ft"
 };  EO_VERIFYsizeof(s_mn_servicetype_strings, eomn_serv_types_numberof*sizeof(const char *))   
  
 static const char * s_mn_servicetype_string_unknown = "eomn_serv_UNKNOWN";

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -46,6 +46,7 @@ extern "C" {
 #include "EoCommon.h"
 #include "EOarray.h"
 #include "EOrop.h"
+#include "EoBoards.h"
 
 #include "EoAnalogSensors.h"
 #include "EoMotionControl.h"
@@ -538,13 +539,14 @@ typedef struct
 
 
 typedef struct
-{   // 36  
+{   // 4 + 36  
+    eObrd_canmonitor_cfg_t              canmonitorconfig;
     eOas_ft_arrayof_sensors_t           arrayofsensors;
-} eOmn_serv_config_data_as_ft_t;        EO_VERIFYsizeof(eOmn_serv_config_data_as_ft_t, 36)
+} eOmn_serv_config_data_as_ft_t;        EO_VERIFYsizeof(eOmn_serv_config_data_as_ft_t, 40)
 
 
 typedef union
-{   // max(6, 6, 44, 108, 156, 8, 6, 36)
+{   // max(6, 6, 44, 108, 156, 8, 6, 40)
     eOmn_serv_config_data_as_mais_t         mais;
     eOmn_serv_config_data_as_strain_t       strain;
     eOmn_serv_config_data_as_temperature_t  temperature;

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -435,12 +435,13 @@ typedef enum
     eomn_serv_category_temperatures     = 6,
     eomn_serv_category_psc              = 7,
     eomn_serv_category_pos              = 8,
+    eomn_serv_category_ft               = 9,
     eomn_serv_category_all              = 128,
     eomn_serv_category_unknown          = 254,
     eomn_serv_category_none             = 255
 } eOmn_serv_category_t;
 
-enum { eomn_serv_categories_numberof = 9 };
+enum { eomn_serv_categories_numberof = 10 };
 
 typedef enum 
 {
@@ -461,11 +462,12 @@ typedef enum
     eomn_serv_AS_pos            = 14,
     eomn_serv_MC_mc4plusfaps    = 15,
     eomn_serv_MC_mc4pluspmc     = 16,
+    eomn_serv_AS_ft             = 17,
     eomn_serv_UNKNOWN           = 254,
     eomn_serv_NONE              = 255
 } eOmn_serv_type_t;
 
-enum { eomn_serv_types_numberof = 17 };
+enum { eomn_serv_types_numberof = 18 };
 
 typedef enum
 {
@@ -535,8 +537,14 @@ typedef struct
 } eOmn_serv_config_data_as_pos_t;       EO_VERIFYsizeof(eOmn_serv_config_data_as_pos_t, 6)
 
 
+typedef struct
+{   // 36  
+    eOas_ft_arrayof_sensors_t           arrayofsensors;
+} eOmn_serv_config_data_as_ft_t;        EO_VERIFYsizeof(eOmn_serv_config_data_as_ft_t, 36)
+
+
 typedef union
-{   // max(6, 6, 44, 108, 156, 8, 6)
+{   // max(6, 6, 44, 108, 156, 8, 6, 36)
     eOmn_serv_config_data_as_mais_t         mais;
     eOmn_serv_config_data_as_strain_t       strain;
     eOmn_serv_config_data_as_temperature_t  temperature;
@@ -544,6 +552,7 @@ typedef union
     eOmn_serv_config_data_as_inertial3_t    inertial3;
     eOmn_serv_config_data_as_psc_t          psc;
     eOmn_serv_config_data_as_pos_t          pos;
+    eOmn_serv_config_data_as_ft_t           ft;
 } eOmn_serv_config_data_as_t;               EO_VERIFYsizeof(eOmn_serv_config_data_as_t, 156)
 
 
@@ -743,7 +752,7 @@ typedef struct
 typedef struct
 {   // 32 + 32
     uint8_t                                 stateofservice[eomn_serv_categories_numberof];     // use eOmn_serv_state_t
-    uint8_t                                 filler[7];    
+    uint8_t                                 filler[6];    
     eOmn_service_command_result_t           commandresult;
 } eOmn_service_status_t;                    EO_VERIFYsizeof(eOmn_service_status_t, 48) 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
@@ -215,12 +215,13 @@ typedef enum
     eoprot_entity_as_inertial               = eoas_entity_inertial,     /**<  */   
     eoprot_entity_as_inertial3              = eoas_entity_inertial3,    /**<  */  
     eoprot_entity_as_psc                    = eoas_entity_psc,          /**<  */   
-    eoprot_entity_as_pos                    = eoas_entity_pos,          /**<  */        
+    eoprot_entity_as_pos                    = eoas_entity_pos,          /**<  */ 
+    eoprot_entity_as_ft                     = eoas_entity_ft,           /**<  */      
     eoprot_entity_sk_skin                   = eosk_entity_skin,         /**<  */
     eoprot_entity_none                      = EOK_uint08dummy
 } eOprot_entity_t;
 
-enum { eoprot_entities_numberof = 15 }; // it does not count the eoprot_entity_none.
+enum { eoprot_entities_numberof = 16 }; // it does not count the eoprot_entity_none.
 
 
 /** @typedef    typedef enum eOprot_index_t
@@ -270,7 +271,7 @@ typedef struct
 } eOprot_callbacks_endpoint_descriptor_t;
 
 
-enum { eoprot_maxvalueof_entity = 6 }; // must be higher equal than the values inside eOprot_entity_t
+enum { eoprot_maxvalueof_entity = 7 }; // must be higher equal than the values inside eOprot_entity_t
 enum { eoprot_entities_maxnumberofsupported = eoprot_maxvalueof_entity+1 }; // it is used to shape data structures
 // it is what is enough to configure an endpoint
 typedef struct                     

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 5 };
+enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 6 };
 
 
 enum { eoprot_entities_as_numberof = eoas_entities_numberof };
@@ -312,6 +312,41 @@ typedef enum
 enum { eoprot_rwms_as_pos_numberof = 4 };  // it MUST be equal to the number of rw modes. 
 
 
+// - entity ft
+
+
+/** @typedef    typedef enum eOprot_tag_as_ft_t
+    @brief      It contains the tags for all variables of the ft entity.
+                See definition of eOas_ft_t (and its fields) in file EoAnalogSensors.h for explanation of the variables.
+ **/
+typedef enum
+{
+    eoprot_tag_as_ft_config                                        = 0,
+    eoprot_tag_as_ft_cmmnds_enable                                 = 1,
+    eoprot_tag_as_ft_status                                        = 2,
+    eoprot_tag_as_ft_status_timedvalue                             = 3,
+    eoprot_tag_as_ft_status_fullscale                              = 4
+} eOprot_tag_as_ft_t;
+
+enum { eoprot_tags_as_ft_numberof = 5 };  // it MUST be equal to the number of tags. 
+
+
+/** @typedef    typedef enum eOprot_rwm_as_ft_t
+    @brief      It contains the rw modes for all variables of the ft entity. There must be a one-to-one
+                correspondence to the values in eOprot_tag_as_ft_t.
+ **/
+typedef enum
+{
+    eoprot_rwm_as_ft_config                                        = eo_nv_rwmode_RW,
+    eoprot_rwm_as_ft_cmmnds_enable                                 = eo_nv_rwmode_RW,
+    eoprot_rwm_as_ft_status                                        = eo_nv_rwmode_RO,
+    eoprot_rwm_as_ft_status_timedvalue                             = eo_nv_rwmode_RO,
+    eoprot_rwm_as_ft_status_fullscale                              = eo_nv_rwmode_RO    
+} eOprot_rwm_as_ft_t; 
+
+enum { eoprot_rwms_as_ft_numberof = 5 };  // it MUST be equal to the number of rw modes. 
+
+
 
 // - structures implementing the endpoints
 
@@ -328,6 +363,7 @@ typedef struct                  // 56*1+48*1+8*1 = 112
     eOas_inertial3_t            inertial3[1];
     eOas_psc_t                  psc[1];
     eOas_pos_t                  pos[1];
+    eOas_ft_t                   ft[1];
 } eOprot_template_as_t;         //EO_VERIFYsizeof(eOprot_template_as_t, 112);
   
   
@@ -472,6 +508,22 @@ extern void eoprot_fun_UPDT_as_pos_status(const EOnv* nv, const eOropdescriptor_
 extern void eoprot_fun_INIT_as_pos_cmmnds_enable(const EOnv* nv);
 extern void eoprot_fun_UPDT_as_pos_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd);
 
+// -- ft
+
+extern void eoprot_fun_INIT_as_ft_config(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_ft_config(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_ft_cmmnds_enable(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_ft_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_ft_status(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_ft_status(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_ft_status_fullscale(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_ft_status_fullscale(const EOnv* nv, const eOropdescriptor_t* rd);
+
+extern void eoprot_fun_INIT_as_ft_status_timedvalue(const EOnv* nv);
+extern void eoprot_fun_UPDT_as_ft_status_timedvalue(const EOnv* nv, const eOropdescriptor_t* rd);
 
 /** @}            
     end of group eo_EoProtocolAS  

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 20 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 21 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocol.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocol.c
@@ -123,20 +123,20 @@ const eOprot_EPcfg_t eoprot_arrayof_stdEPcfg[eoprot_endpoints_numberof] =
 {
     {
         EO_INIT(.endpoint)          eoprot_endpoint_management,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 0, 0, 0}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 0, 0, 0, 0}
     },
   
     {
         EO_INIT(.endpoint)          eoprot_endpoint_motioncontrol,
-        EO_INIT(.numberofentities)  {4, 4, 1, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {4, 4, 1, 0, 0, 0, 0, 0}
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1, eOas_ft_sensors_maxnumber}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,
-        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0, 0}
     }      
 };
 
@@ -144,20 +144,20 @@ const eOprot_EPcfg_t eoprot_arrayof_maxEPcfg[eoprot_endpoints_numberof] =
 {
     {
         EO_INIT(.endpoint)          eoprot_endpoint_management,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 0, 0, 0}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 0, 0, 0, 0}
     },
   
     {
         EO_INIT(.endpoint)          eoprot_endpoint_motioncontrol,
-        EO_INIT(.numberofentities)  {12, 12, 1, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {12, 12, 1, 0, 0, 0, 0, 0}
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1, eOas_ft_sensors_maxnumber}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,
-        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0, 0}
     }    
 };  
 
@@ -166,15 +166,15 @@ const eOprot_EPcfg_t eoprot_arrayof_maxEPcfgOthers[eoprot_endpoints_numberof-1] 
 {
     {
         EO_INIT(.endpoint)          eoprot_endpoint_motioncontrol,
-        EO_INIT(.numberofentities)  {12, 12, 1, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {12, 12, 1, 0, 0, 0, 0, 0}
     }, 
     {
         EO_INIT(.endpoint)          eoprot_endpoint_analogsensors,
-        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1}
+        EO_INIT(.numberofentities)  {1, 1, 1, 1, 1, 1, 1, eOas_ft_sensors_maxnumber}
     },
     {
         EO_INIT(.endpoint)          eoprot_endpoint_skin,
-        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0}
+        EO_INIT(.numberofentities)  {2, 0, 0, 0, 0, 0, 0, 0}
     }    
 };  
 

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_fun.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_fun.c
@@ -371,8 +371,47 @@ EO_weak extern void eoprot_fun_INIT_as_pos_cmmnds_enable(const EOnv* nv) {}
 #endif
 #if !defined(OVERRIDE_eoprot_fun_UPDT_as_pos_cmmnds_enable)
 EO_weak extern void eoprot_fun_UPDT_as_pos_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd) {}
-#endif    
+#endif  
+
+
+// -- ft
     
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_ft_config)
+EO_weak extern void eoprot_fun_INIT_as_ft_config(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_ft_config)
+EO_weak extern void eoprot_fun_UPDT_as_ft_config(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_ft_cmmnds_enable)
+EO_weak extern void eoprot_fun_INIT_as_ft_cmmnds_enable(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_ft_cmmnds_enable)
+EO_weak extern void eoprot_fun_UPDT_as_ft_cmmnds_enable(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif  
+    
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_ft_status)
+EO_weak extern void eoprot_fun_INIT_as_ft_status(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_ft_status)
+EO_weak extern void eoprot_fun_UPDT_as_ft_status(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+    
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_ft_status_fullscale)
+EO_weak extern void eoprot_fun_INIT_as_ft_status_fullscale(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_ft_status_fullscale)
+EO_weak extern void eoprot_fun_UPDT_as_ft_status_fullscale(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+
+#if !defined(OVERRIDE_eoprot_fun_INIT_as_ft_status_timedvalue)
+EO_weak extern void eoprot_fun_INIT_as_ft_status_timedvalue(const EOnv* nv) {}
+#endif
+#if !defined(OVERRIDE_eoprot_fun_UPDT_as_ft_status_timedvalue)
+EO_weak extern void eoprot_fun_UPDT_as_ft_status_timedvalue(const EOnv* nv, const eOropdescriptor_t* rd) {}
+#endif
+    
+
 #endif//!defined(EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME)
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_rom.c
+++ b/eth/embobj/plus/comm-v2/protocol/src/EoProtocolAS_rom.c
@@ -108,6 +108,9 @@ static const eOas_psc_t eoprot_as_rom_psc_defaultvalue = { 0 };
 // - default value of a pos
 static const eOas_pos_t eoprot_as_rom_pos_defaultvalue = { 0 };
 
+// - default value of a ft
+static const eOas_ft_t eoprot_as_rom_ft_defaultvalue = { 0 };
+
 // - descriptors for the variables of a strain
 
 static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_strain_wholeitem =
@@ -659,6 +662,88 @@ static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_pos_cmmnds_enable =
 #endif
 };
 
+
+
+// - descriptors for the variables of a ft
+
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_ft_config =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_ft_defaultvalue.config),
+    EO_INIT(.rwmode)    eoprot_rwm_as_ft_config,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_ft_defaultvalue.config,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_ft_config,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_ft_config
+#endif
+};
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_ft_cmmnds_enable =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_ft_defaultvalue.cmmnds.enable),
+    EO_INIT(.rwmode)    eoprot_rwm_as_ft_cmmnds_enable,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_ft_defaultvalue.cmmnds.enable,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_ft_cmmnds_enable,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_ft_cmmnds_enable
+#endif
+};
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_ft_status =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_ft_defaultvalue.status),
+    EO_INIT(.rwmode)    eoprot_rwm_as_ft_status,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_ft_defaultvalue.status,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_ft_status,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_ft_status
+#endif
+};
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_ft_status_timedvalue =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_ft_defaultvalue.status.timedvalue),
+    EO_INIT(.rwmode)    eoprot_rwm_as_ft_status_timedvalue,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_ft_defaultvalue.status.timedvalue,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_ft_status_timedvalue,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_ft_status_timedvalue
+#endif
+};
+
+
+static EOPROT_ROMmap EOnv_rom_t eoprot_as_rom_descriptor_ft_status_fullscale =
+{   
+    EO_INIT(.capacity)  sizeof(eoprot_as_rom_ft_defaultvalue.status.fullscale),
+    EO_INIT(.rwmode)    eoprot_rwm_as_ft_status_fullscale,
+    EO_INIT(.dummy)     0,    
+    EO_INIT(.resetval)  (const void*)&eoprot_as_rom_ft_defaultvalue.status.fullscale,
+#ifdef EOPROT_CFG_OVERRIDE_CALLBACKS_IN_RUNTIME
+    EO_INIT(.init)      NULL,
+    EO_INIT(.update)    NULL
+#else       
+    EO_INIT(.init)      eoprot_fun_INIT_as_ft_status_fullscale,
+    EO_INIT(.update)    eoprot_fun_UPDT_as_ft_status_fullscale
+#endif
+};
+
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
 // --------------------------------------------------------------------------------------------------------------------
@@ -712,7 +797,7 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_inertial_descriptors[] =
 };  EO_VERIFYsizeof(s_eoprot_as_rom_inertial_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_inertial_numberof))
 
 static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_inertial3_descriptors[] =
-{   // here are eoprot_tags_as_inertial_numberof descriptors for the inertial entity
+{   // here are eoprot_tags_as_inertial3_numberof descriptors for the inertial entity
     &eoprot_as_rom_descriptor_inertial3_wholeitem,
     &eoprot_as_rom_descriptor_inertial3_config,
     &eoprot_as_rom_descriptor_inertial3_status,
@@ -721,7 +806,7 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_inertial3_descriptors[] 
 
 
 static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_psc_descriptors[] =
-{   // here are eoprot_tags_as_inertial_numberof descriptors for the inertial entity
+{   // here are eoprot_tags_as_psc_numberof descriptors for the inertial entity
     &eoprot_as_rom_descriptor_psc_wholeitem,
     &eoprot_as_rom_descriptor_psc_config,
     &eoprot_as_rom_descriptor_psc_status,
@@ -729,12 +814,22 @@ static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_psc_descriptors[] =
 };  EO_VERIFYsizeof(s_eoprot_as_rom_psc_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_psc_numberof))
 
 static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_pos_descriptors[] =
-{   // here are eoprot_tags_as_inertial_numberof descriptors for the inertial entity
+{   // here are eoprot_tags_as_pos_numberof descriptors for the inertial entity
     &eoprot_as_rom_descriptor_pos_wholeitem,
     &eoprot_as_rom_descriptor_pos_config,
     &eoprot_as_rom_descriptor_pos_status,
     &eoprot_as_rom_descriptor_pos_cmmnds_enable
 };  EO_VERIFYsizeof(s_eoprot_as_rom_pos_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_pos_numberof))
+
+
+static EOPROT_ROMmap EOnv_rom_t * const s_eoprot_as_rom_ft_descriptors[] =
+{   // here are eoprot_tags_as_inertial_numberof descriptors for the inertial entity
+    &eoprot_as_rom_descriptor_ft_config,
+    &eoprot_as_rom_descriptor_ft_cmmnds_enable,
+    &eoprot_as_rom_descriptor_ft_status,
+    &eoprot_as_rom_descriptor_ft_status_timedvalue,
+    &eoprot_as_rom_descriptor_ft_status_fullscale,
+};  EO_VERIFYsizeof(s_eoprot_as_rom_ft_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t* const)*(eoprot_tags_as_ft_numberof))
 
 EOPROT_ROMmap EOnv_rom_t * const * const eoprot_as_rom_descriptors[] = 
 {
@@ -744,7 +839,8 @@ EOPROT_ROMmap EOnv_rom_t * const * const eoprot_as_rom_descriptors[] =
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_inertial_descriptors,
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_inertial3_descriptors,
     (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_psc_descriptors,
-    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_pos_descriptors
+    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_pos_descriptors,
+    (EOPROT_ROMmap EOnv_rom_t **)&s_eoprot_as_rom_ft_descriptors
 };  EO_VERIFYsizeof(eoprot_as_rom_descriptors, sizeof(EOPROT_ROMmap EOnv_rom_t** const)*(eoprot_entities_as_numberof))
 
 
@@ -758,7 +854,8 @@ const uint8_t eoprot_as_rom_tags_numberof[] =
     eoprot_tags_as_inertial_numberof,
     eoprot_tags_as_inertial3_numberof,
     eoprot_tags_as_psc_numberof,
-    eoprot_tags_as_pos_numberof
+    eoprot_tags_as_pos_numberof,
+    eoprot_tags_as_ft_numberof
 };  EO_VERIFYsizeof(eoprot_as_rom_tags_numberof, eoprot_entities_as_numberof*sizeof(uint8_t)) 
 
 const uint16_t eoprot_as_rom_entities_sizeof[] = 
@@ -769,7 +866,8 @@ const uint16_t eoprot_as_rom_entities_sizeof[] =
     sizeof(eOas_inertial_t),
     sizeof(eOas_inertial3_t),
     sizeof(eOas_psc_t),
-    sizeof(eOas_pos_t)
+    sizeof(eOas_pos_t),
+    sizeof(eOas_ft_t)
 };  EO_VERIFYsizeof(eoprot_as_rom_entities_sizeof, eoprot_entities_as_numberof*sizeof(uint16_t)) 
 
 const void* const eoprot_as_rom_entities_defval[] = 
@@ -780,7 +878,8 @@ const void* const eoprot_as_rom_entities_defval[] =
     (const void*)&eoprot_as_rom_inertial_defaultvalue,
     (const void*)&eoprot_as_rom_inertial3_defaultvalue,
     (const void*)&eoprot_as_rom_psc_defaultvalue,
-    (const void*)&eoprot_as_rom_pos_defaultvalue
+    (const void*)&eoprot_as_rom_pos_defaultvalue,
+    (const void*)&eoprot_as_rom_ft_defaultvalue
 };  EO_VERIFYsizeof(eoprot_as_rom_entities_defval, eoprot_entities_as_numberof*sizeof(const void*)) 
 
 
@@ -794,7 +893,8 @@ const char * const eoprot_as_strings_entity[] =
     "eoprot_entity_as_inertial",
     "eoprot_entity_as_inertial3",
     "eoprot_entity_as_psc",
-    "eoprot_entity_as_pos"
+    "eoprot_entity_as_pos",
+    "eoprot_entity_as_ft"
 };  EO_VERIFYsizeof(eoprot_as_strings_entity, eoprot_entities_as_numberof*sizeof(const char*)) 
 
 
@@ -861,6 +961,17 @@ static const char * const s_eoprot_as_strings_tags_pos[] =
     "eoprot_tag_as_pos_cmmnds_enable"
 };  EO_VERIFYsizeof(s_eoprot_as_strings_tags_pos, eoprot_tags_as_pos_numberof*sizeof(const char*))
 
+
+static const char * const s_eoprot_as_strings_tags_ft[] =
+{
+    "eoprot_tag_as_ft_config",
+    "eoprot_tag_as_ft_cmmnds_enable",
+    "eoprot_tag_as_ft_status",
+    "eoprot_tag_as_ft_status_fullscale",
+    "eoprot_tag_as_ft_status_timedvalue",
+};  EO_VERIFYsizeof(s_eoprot_as_strings_tags_ft, eoprot_tags_as_ft_numberof*sizeof(const char*)) 
+
+
 const char ** const eoprot_as_strings_tags[] =
 {
     (const char**)&s_eoprot_as_strings_tags_strain,   
@@ -869,7 +980,8 @@ const char ** const eoprot_as_strings_tags[] =
     (const char**)&s_eoprot_as_strings_tags_inertial,
     (const char**)&s_eoprot_as_strings_tags_inertial3,
     (const char**)&s_eoprot_as_strings_tags_psc,
-    (const char**)&s_eoprot_as_strings_tags_pos
+    (const char**)&s_eoprot_as_strings_tags_pos,
+    (const char**)&s_eoprot_as_strings_tags_ft
 };  EO_VERIFYsizeof(eoprot_as_strings_tags, eoprot_entities_as_numberof*sizeof(const char**)) 
 
 


### PR DESCRIPTION
### Description
This PR with its companion PRs in [icub-firmware](https://github.com/robotology/icub-firmware/pull/257) and [icub-firmware-build](https://github.com/robotology/icub-firmware-build/pull/52) allow an ETH board such as the `ems`, `mc4plus`, `mc2plus` to stream FT data and associated temperature coming from one, two or more CAN FT sensor boards such as the `strain2` or the `strain`.

The changes generated by the above triad of PRs (`icub-firmware`, `icub-firmware-shared`, `icub-firmware-build`) can coexist safely with current release of `icub-main/devel`, even if the multiple FT service cannot be activated yet.

For further details see https://github.com/robotology/icub-firmware/pull/257.
