### PR TITLE
eoboards_string2reportmode() -> corrected bug due to typo

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -583,8 +583,8 @@ extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mod
 extern eObrd_canmonitor_reportmode_t eoboards_string2reportmode(const char * string, eObool_t usecompactstring)
 {
     const eOmap_str_str_u08_t * map = s_boards_map_of_reportmodes;
-    const uint8_t size = eobrd_portposs_numberof+2;
-    const uint8_t defvalue = eobrd_portpos_unknown;
+    const uint8_t size = eobrd_reportmodes_numberof+2;
+    const uint8_t defvalue = eobrd_canmonitor_reportmode_unknown;
     
     return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }


### PR DESCRIPTION
This PR corrects a bug inside  `eoboards_string2reportmode()`  due to a typo which was  introduced in the previous [PR](https://github.com/robotology/icub-firmware-shared/pull/58).

 The function `eoboards_string2reportmode()` will be used in `icub-main` to convert the string read from the xml files into valid `eObrd_canmonitor_reportmode_t` values for the future `embObjMultipleFTsensors` service.

Thanx @triccyx for having spotted the bug.
 