### PR TITLE
ETH environment for the amc board

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -70,7 +70,8 @@
 
 static const uint64_t s_eoboards_is_eth_mask =  (0x1LL << eobrd_ems4) | 
                                                 (0x1LL << eobrd_mc4plus) | 
-                                                (0x1LL << eobrd_mc2plus);
+                                                (0x1LL << eobrd_mc2plus) |
+                                                (0x1LL << eobrd_amc);
 
 static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) | 
                                                 (0x1LL << eobrd_mtb) | 
@@ -98,6 +99,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"ems4", "eobrd_ems4", eobrd_ems4},
     {"mc4plus", "eobrd_mc4plus", eobrd_mc4plus},
     {"mc2plus", "eobrd_mc2plus", eobrd_mc2plus},
+    {"amc", "eobrd_amc", eobrd_amc},
     
     {"mc4", "eobrd_mc4", eobrd_mc4},
     {"mtb", "eobrd_mtb", eobrd_mtb},

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -88,12 +88,13 @@ typedef enum
     eobrd_ethtype_ems4              = 32,      
     eobrd_ethtype_mc4plus           = 33,     
     eobrd_ethtype_mc2plus           = 34,   
-   
+    eobrd_ethtype_amc               = 35,
+    
     eobrd_ethtype_none              = 254, 	
     eobrd_ethtype_unknown           = 255  // = ICUBCANPROTO_BOARDTYPE__UNKNOWN 
 } eObrd_ethtype_t;
 
-enum { eobrd_ethtype_numberof = 3 };
+enum { eobrd_ethtype_numberof = 4 };
 
 
 // use eoboards_is_can() / eoboards_is_eth() to check if the eObrd_type_t belongs also to eObrd_cantype_t / eObrd_ethtype_t group.
@@ -105,7 +106,8 @@ typedef enum
     eobrd_ems4                  = eobrd_ethtype_ems4,       // associated string is: "eobrd_ems4"
     eobrd_mc4plus               = eobrd_ethtype_mc4plus,    // etc ... the string is equal to the enum
     eobrd_mc2plus               = eobrd_ethtype_mc2plus,     
-        
+    eobrd_amc                   = eobrd_ethtype_amc,
+    
     eobrd_mc4                   = eobrd_cantype_mc4,        
     eobrd_mtb                   = eobrd_cantype_mtb,        
     eobrd_strain                = eobrd_cantype_strain,     
@@ -131,7 +133,7 @@ typedef enum
     eobrd_unknown               = 255  // = ICUBCANPROTO_BOARDTYPE__UNKNOWN                     
 } eObrd_type_t;
 
-enum { eobrd_type_numberof = 22 };
+enum { eobrd_type_numberof = 23 };
 
 
 typedef struct                  


### PR DESCRIPTION
This PR contains the support for recognizing and printing the name of the `amc` board inside `FirmwareUpdater`.

It comes with a companion [PR](https://github.com/robotology/icub-firmware/pull/264), where we have added support in the `amc` board to talk to `FirmwareUpdater`.
