### PR TITLE
Added mtb4c support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.26.0)
+        VERSION 1.26.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/can/canProtocolLib/iCubCanProto_types.h
+++ b/can/canProtocolLib/iCubCanProto_types.h
@@ -77,6 +77,7 @@ extern "C" {
 #define ICUBCANPROTO_BOARDTYPE__PMC     17
 #define ICUBCANPROTO_BOARDTYPE__AMCBLDC 18
 #define ICUBCANPROTO_BOARDTYPE__BMS     19
+#define ICUBCANPROTO_BOARDTYPE__MTB4C   20
 #define ICUBCANPROTO_BOARDTYPE__UNKNOWN 255
 
 // skin types
@@ -113,6 +114,7 @@ typedef enum
     icubCanProto_boardType__pmc     = ICUBCANPROTO_BOARDTYPE__PMC,
     icubCanProto_boardType__amcbldc = ICUBCANPROTO_BOARDTYPE__AMCBLDC,
     icubCanProto_boardType__bms     = ICUBCANPROTO_BOARDTYPE__BMS,
+    icubCanProto_boardType__mtb4c     = ICUBCANPROTO_BOARDTYPE__MTB4C,
     icubCanProto_boardType__unknown = ICUBCANPROTO_BOARDTYPE__UNKNOWN
 } icubCanProto_boardType_t;
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -152,9 +152,9 @@ extern eOas_sensor_t eoas_string2sensor(const char * string)
     return(eoas_unknown);    
 }
 
-enum { in3_mtb_pos = 0, in3_mtb4_pos = 1, in3_strain2_pos = 2, in3_rfe_pos = 3 };
+enum { in3_mtb_pos = 0, in3_mtb4_pos = 1, in3_strain2_pos = 2, in3_rfe_pos = 3, in3_mtb4c_pos = 4 };
 
-static const eObrd_cantype_t s_eoas_inertial3_supportedboards_types[] = { eobrd_cantype_mtb, eobrd_cantype_mtb4, eobrd_cantype_strain2, eobrd_cantype_rfe };
+static const eObrd_cantype_t s_eoas_inertial3_supportedboards_types[] = { eobrd_cantype_mtb, eobrd_cantype_mtb4, eobrd_cantype_strain2, eobrd_cantype_rfe, eobrd_cantype_mtb4c };
 
 
 extern uint8_t eoas_inertial3_supportedboards_numberof(void)
@@ -220,7 +220,13 @@ extern eOresult_t eoas_inertial3_setof_boardinfos_add(eOas_inertial3_setof_board
     {
         memcpy(&set->data[in3_rfe_pos], brdinfo, sizeof(eObrd_info_t));
         return eores_OK;       
-    }  
+    }
+    
+    if(eobrd_cantype_mtb4c == brdinfo->type)
+    {
+        memcpy(&set->data[in3_mtb4c_pos], brdinfo, sizeof(eObrd_info_t));
+        return eores_OK;       
+    }    
     
     return eores_NOK_generic;
 }
@@ -268,7 +274,15 @@ extern const eObrd_info_t * eoas_inertial3_setof_boardinfos_find(const eOas_iner
             {
                 r = &set->data[in3_rfe_pos];
             }
-        } break;        
+        } break;  
+
+        case eobrd_cantype_mtb4c:
+        {
+            if(eobrd_cantype_mtb4c == set->data[in3_mtb4c_pos].type)
+            {
+                r = &set->data[in3_mtb4c_pos];
+            }
+        } break;         
         
         default: 
         {
@@ -326,10 +340,9 @@ extern eOas_inertial3_type_t eoas_inertial3_canproto_to_imu(uint8_t v)
 }
 
 
-enum { temp_mtb4_pos = 0, temp_strain2_pos = 1 };
+enum { temp_mtb4_pos = 0, temp_strain2_pos = 1, temp_mtb4c_pos = 2 };
 
-static const eObrd_cantype_t s_eoas_temperature_supportedboards_types[] = { eobrd_cantype_mtb4, eobrd_cantype_strain2 };
-
+static const eObrd_cantype_t s_eoas_temperature_supportedboards_types[] = { eobrd_cantype_mtb4, eobrd_cantype_strain2, eobrd_cantype_mtb4c };
 
 extern uint8_t eoas_temperature_supportedboards_numberof(void)
 {
@@ -381,7 +394,13 @@ extern eOresult_t eoas_temperature_setof_boardinfos_add(eOas_temperature_setof_b
     {
         memcpy(&set->data[temp_strain2_pos], brdinfo, sizeof(eObrd_info_t));
         return eores_OK;       
-    }    
+    }
+
+    if(eobrd_cantype_mtb4c == brdinfo->type)
+    {
+        memcpy(&set->data[temp_mtb4c_pos], brdinfo, sizeof(eObrd_info_t));
+        return eores_OK;       
+    }        
     
     return eores_NOK_generic;
 }
@@ -411,6 +430,14 @@ extern const eObrd_info_t * eoas_temperature_setof_boardinfos_find(const eOas_te
             if(eobrd_cantype_strain2 == set->data[temp_strain2_pos].type)
             {
                 r = &set->data[temp_strain2_pos];
+            }
+        } break;
+
+        case eobrd_cantype_mtb4c:
+        {
+            if(eobrd_cantype_mtb4c == set->data[temp_mtb4c_pos].type)
+            {
+                r = &set->data[temp_mtb4c_pos];
             }
         } break;
         

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -315,11 +315,11 @@ typedef struct
 
 
 // we use this struct to send activate-verify command to the board
-enum { eOas_temperature_boardinfos_maxnumber = 2 };
+enum { eOas_temperature_boardinfos_maxnumber = 3 };
 typedef struct
-{   //6*2=12
+{   //6*3=12
     eObrd_info_t                    data[eOas_temperature_boardinfos_maxnumber];
-} eOas_temperature_setof_boardinfos_t; EO_VERIFYsizeof(eOas_temperature_setof_boardinfos_t, 12)
+} eOas_temperature_setof_boardinfos_t; EO_VERIFYsizeof(eOas_temperature_setof_boardinfos_t, 18)
 
 
 // this struct describes the data acquired by a single temperature sensor
@@ -489,11 +489,11 @@ typedef struct
 
 
 // we use this struct to send activate-verify command to the board
-enum { eOas_inertials3_boardinfos_maxnumber = 4 };
+enum { eOas_inertials3_boardinfos_maxnumber = 5 };
 typedef struct
-{   //6*4=24
+{   //6*5=30
     eObrd_info_t                    data[eOas_inertials3_boardinfos_maxnumber];
-} eOas_inertial3_setof_boardinfos_t; EO_VERIFYsizeof(eOas_inertial3_setof_boardinfos_t, 24)
+} eOas_inertial3_setof_boardinfos_t; EO_VERIFYsizeof(eOas_inertial3_setof_boardinfos_t, 30)
 
 typedef struct
 {

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -92,7 +92,8 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_mtb4w) |
                                                 (0x1LL << eobrd_pmc)   |
                                                 (0x1LL << eobrd_amcbldc)|
-                                                (0x1LL << eobrd_bms);
+                                                (0x1LL << eobrd_bms)|
+                                                (0x1LL << eobrd_mtb4c);
        
    
 static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
@@ -123,6 +124,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"pmc", "eobrd_pmc", eobrd_pmc},
     {"amcbldc", "eobrd_amcbldc", eobrd_amcbldc},
     {"bms", "eobrd_bms", eobrd_bms},
+    {"mtb4c", "eobrd_mtb4c", eobrd_mtb4c},
     
     {"none", "eobrd_none", eobrd_none},
     {"unknown", "eobrd_unknown", eobrd_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -76,12 +76,13 @@ typedef enum
     eobrd_cantype_mtb4w             = ICUBCANPROTO_BOARDTYPE__MTB4W,    // 16 (mtb4 for waseda university)
     eobrd_cantype_pmc               = ICUBCANPROTO_BOARDTYPE__PMC,      // 17 (pmc = piezo motor control)
     eobrd_cantype_amcbldc           = ICUBCANPROTO_BOARDTYPE__AMCBLDC,  // 18 (amcbldc)
-    eobrd_cantype_bms        = ICUBCANPROTO_BOARDTYPE__BMS,      // 19 (bms)
+    eobrd_cantype_bms               = ICUBCANPROTO_BOARDTYPE__BMS,      // 19 (bms)
+    eobrd_cantype_mtb4c             = ICUBCANPROTO_BOARDTYPE__MTB4C,    // 20 (mtb4c)    
     eobrd_cantype_none              = 254, 	
     eobrd_cantype_unknown           = ICUBCANPROTO_BOARDTYPE__UNKNOWN   // 255 
 } eObrd_cantype_t;
 
-enum { eobrd_cantype_numberof = 19 };
+enum { eobrd_cantype_numberof = 21 };
 
 
 typedef enum
@@ -129,13 +130,14 @@ typedef enum
     eobrd_mtb4w                 = eobrd_cantype_mtb4w,
     eobrd_pmc                   = eobrd_cantype_pmc,
     eobrd_amcbldc               = eobrd_cantype_amcbldc,
-    eobrd_bms            = eobrd_cantype_bms,
+    eobrd_bms                   = eobrd_cantype_bms,
+    eobrd_mtb4c                 = eobrd_cantype_mtb4c,
 
     eobrd_none                  = 254,                      
     eobrd_unknown               = 255  // = ICUBCANPROTO_BOARDTYPE__UNKNOWN                     
 } eObrd_type_t;
 
-enum { eobrd_type_numberof = 24 };
+enum { eobrd_type_numberof = 25 };
 
 
 typedef struct                  

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -513,17 +513,17 @@ typedef struct
 
 
 typedef struct
-{   // 24+132=156 
+{   // 30+132=162 
     eOas_inertial3_setof_boardinfos_t       setofboardinfos;
     eOas_inertial3_arrayof_descriptors_t    arrayofdescriptor;
-} eOmn_serv_config_data_as_inertial3_t;     EO_VERIFYsizeof(eOmn_serv_config_data_as_inertial3_t, 156)
+} eOmn_serv_config_data_as_inertial3_t;     EO_VERIFYsizeof(eOmn_serv_config_data_as_inertial3_t, 162)
 
 
 typedef struct
-{   // 12+32=44 
+{   // 18+32=50 
     eOas_temperature_setof_boardinfos_t       setofboardinfos;
     eOas_temperature_arrayof_descriptors_t    arrayofdescriptor;
-} eOmn_serv_config_data_as_temperature_t;     EO_VERIFYsizeof(eOmn_serv_config_data_as_temperature_t, 44)
+} eOmn_serv_config_data_as_temperature_t;     EO_VERIFYsizeof(eOmn_serv_config_data_as_temperature_t, 50)
 
 
 typedef struct
@@ -553,7 +553,7 @@ typedef struct
 } eOmn_serv_config_data_as_battery_t;        EO_VERIFYsizeof(eOmn_serv_config_data_as_battery_t, 16)
 
 typedef union
-{   // max(6, 6, 44, 108, 156, 8, 6, 40)
+{   // max(6, 6, 44, 108, 162, 8, 6, 40)
     eOmn_serv_config_data_as_mais_t         mais;
     eOmn_serv_config_data_as_strain_t       strain;
     eOmn_serv_config_data_as_temperature_t  temperature;
@@ -563,7 +563,7 @@ typedef union
     eOmn_serv_config_data_as_pos_t          pos;
     eOmn_serv_config_data_as_ft_t           ft;
     eOmn_serv_config_data_as_battery_t      battery;
-} eOmn_serv_config_data_as_t;               EO_VERIFYsizeof(eOmn_serv_config_data_as_t, 156)
+} eOmn_serv_config_data_as_t;               EO_VERIFYsizeof(eOmn_serv_config_data_as_t, 162)
 
 
 enum { eomn_serv_skin_maxpatches = 4 };

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 7 };
+enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 8 };
 
 
 enum { eoprot_entities_as_numberof = eoas_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 23 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 22 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 22 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 23 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };


### PR DESCRIPTION
This PR adds support for the `mtb4c` boards and fixes the [eobrd_cantype_numberof](https://github.com/robotology/icub-firmware-shared/blob/bbb55d49051a6e9b7a39b77f70e372822089d40f/eth/embobj/plus/comm-v2/icub/EoBoards.h#L84) value.

cc @triccyx 