### PR TITLE
AMC – Add support for `J5_XY` connectors for AMC board

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -181,9 +181,9 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mc2plusP10", "eobrd_port_mc2plusP10", eobrd_port_mc2plusP10, eobrd_mc2plus, eobrd_conn_P10},
     {"mc2plusP11", "eobrd_port_mc2plusP11", eobrd_port_mc2plusP11, eobrd_mc2plus, eobrd_conn_P11},
 
-    {"amcP1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
-    {"amcP2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
-    {"amcP3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
+    {"amcJ5_X1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
+    {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
+    {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -177,6 +177,10 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mc2plusP3", "eobrd_port_mc2plusP3", eobrd_port_mc2plusP3, eobrd_mc2plus, eobrd_conn_P3},
     {"mc2plusP10", "eobrd_port_mc2plusP10", eobrd_port_mc2plusP10, eobrd_mc2plus, eobrd_conn_P10},
     {"mc2plusP11", "eobrd_port_mc2plusP11", eobrd_port_mc2plusP11, eobrd_mc2plus, eobrd_conn_P11},
+
+    {"amcP1", "eobrd_port_amcP1", eobrd_port_amcP1, eobrd_amc, eobrd_conn_P1},
+    {"amcP2", "eobrd_port_amcP2", eobrd_port_amcP2, eobrd_amc, eobrd_conn_P2},
+    {"amcP3", "eobrd_port_amcP3", eobrd_port_amcP3, eobrd_amc, eobrd_conn_P3},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -151,6 +151,9 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"P13", "eobrd_conn_P13", eobrd_conn_P13},
     {"P14", "eobrd_conn_P14", eobrd_conn_P14},
     {"P15", "eobrd_conn_P15", eobrd_conn_P15},
+    {"J5_X1", "eobrd_conn_J5_X1", eobrd_conn_J5_X1},
+    {"J5_X2", "eobrd_conn_J5_X2", eobrd_conn_J5_X2},
+    {"J5_X3", "eobrd_conn_J5_X3", eobrd_conn_J5_X3},
     
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
@@ -178,9 +181,9 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mc2plusP10", "eobrd_port_mc2plusP10", eobrd_port_mc2plusP10, eobrd_mc2plus, eobrd_conn_P10},
     {"mc2plusP11", "eobrd_port_mc2plusP11", eobrd_port_mc2plusP11, eobrd_mc2plus, eobrd_conn_P11},
 
-    {"amcP1", "eobrd_port_amcP1", eobrd_port_amcP1, eobrd_amc, eobrd_conn_P1},
-    {"amcP2", "eobrd_port_amcP2", eobrd_port_amcP2, eobrd_amc, eobrd_conn_P2},
-    {"amcP3", "eobrd_port_amcP3", eobrd_port_amcP3, eobrd_amc, eobrd_conn_P3},
+    {"amcP1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
+    {"amcP2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
+    {"amcP3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -325,10 +325,15 @@ typedef enum
     eobrd_port_mc2plusP2            = 1,        // PWM & QUADENC: hal_motor2, hal_quad_enc2
     eobrd_port_mc2plusP3            = 0,        // PWM & QUADENC: hal_motor1, hal_quad_enc1
     eobrd_port_mc2plusP10           = 0,        // SPI encoder: hal_encoder1
-    eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2    
+    eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2   
+
+    eobrd_port_amcP1                = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amcP2                = 1,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amcP3                = 2,        // SPI encoder: embot::hw::encoder3
+
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 16 };
+enum { eobrd_ports_numberof = 19 };
 
 
 typedef enum

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -295,11 +295,14 @@ typedef enum
     eobrd_conn_P13  = 13,
     eobrd_conn_P14  = 14,
     eobrd_conn_P15  = 15,
+    eobrd_conn_J5_X1  = 1,
+    eobrd_conn_J5_X2  = 2,
+    eobrd_conn_J5_X3  = 3,
     eobrd_conn_none = 0,
     eobrd_conn_unknown = 255
 } eObrd_connector_t;
 
-enum { eobrd_connectors_numberof = 15 };
+enum { eobrd_connectors_numberof = 18 };
 
 
 typedef enum
@@ -327,9 +330,9 @@ typedef enum
     eobrd_port_mc2plusP10           = 0,        // SPI encoder: hal_encoder1
     eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2   
 
-    eobrd_port_amcP1                = 0,        // SPI encoder: embot::hw::encoder1
-    eobrd_port_amcP2                = 1,        // SPI encoder: embot::hw::encoder2
-    eobrd_port_amcP3                = 2,        // SPI encoder: embot::hw::encoder3
+    eobrd_port_amc_J5_X1                = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amc_J5_X2                = 1,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amc_J5_X3                = 2,        // SPI encoder: embot::hw::encoder3
 
 } eObrd_port_t;
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -330,9 +330,9 @@ typedef enum
     eobrd_port_mc2plusP10           = 0,        // SPI encoder: hal_encoder1
     eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2   
 
-    eobrd_port_amc_J5_X1                = 0,        // SPI encoder: embot::hw::encoder1
-    eobrd_port_amc_J5_X2                = 1,        // SPI encoder: embot::hw::encoder2
-    eobrd_port_amc_J5_X3                = 2,        // SPI encoder: embot::hw::encoder3
+    eobrd_port_amc_J5_X1                = 1,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amc_J5_X2                = 2,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amc_J5_X3                = 3,        // SPI encoder: embot::hw::encoder3
 
 } eObrd_port_t;
 


### PR DESCRIPTION
What changes this PR:

- Added new fields in `s_eoboards_map_of_connectors` in order to include the new J5 connector for AMC board.

**Notes:**
- Tested on `lego-setup`
- Be sure to use the proper configuration files in [`robots-configuration/experimentalSetups/lego_setup_amc_amcbldc`][1]

[1]: https://github.com/robotology/robots-configuration/tree/devel/experimentalSetups/lego_setup_amc_amcbldc