### PR TITLE
EMS – Add support for AksIM2 encoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.27.0)
+        VERSION 1.27.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -295,9 +295,9 @@ typedef enum
     eobrd_conn_P13  = 13,
     eobrd_conn_P14  = 14,
     eobrd_conn_P15  = 15,
-    eobrd_conn_J5_X1  = 1,
-    eobrd_conn_J5_X2  = 2,
-    eobrd_conn_J5_X3  = 3,
+    eobrd_conn_J5_X1  = 16,
+    eobrd_conn_J5_X2  = 17,
+    eobrd_conn_J5_X3  = 18,
     eobrd_conn_none = 0,
     eobrd_conn_unknown = 255
 } eObrd_connector_t;
@@ -330,9 +330,9 @@ typedef enum
     eobrd_port_mc2plusP10           = 0,        // SPI encoder: hal_encoder1
     eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2   
 
-    eobrd_port_amc_J5_X1                = 1,        // SPI encoder: embot::hw::encoder1
-    eobrd_port_amc_J5_X2                = 2,        // SPI encoder: embot::hw::encoder2
-    eobrd_port_amc_J5_X3                = 3,        // SPI encoder: embot::hw::encoder3
+    eobrd_port_amc_J5_X1                = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amc_J5_X2                = 1,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amc_J5_X3                = 2,        // SPI encoder: embot::hw::encoder3
 
 } eObrd_port_t;
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -84,6 +84,7 @@ static const eOmap_str_str_u08_t s_eomc_map_of_encoders[] =
 {    
     {"aea", "eomc_enc_aea",eomc_enc_aea},
     {"aea3", "eomc_enc_aea3", eomc_enc_aea3},
+    {"aksim2", "eomc_enc_aksim2", eomc_enc_aksim2},
     {"roie", "eomc_enc_roie",eomc_enc_roie},
     {"absanalog", "eomc_enc_absanalog", eomc_enc_absanalog},    
     {"mais", "eomc_enc_mais", eomc_enc_mais},
@@ -274,7 +275,8 @@ extern uint8_t eomc_encoder_get_numberofcomponents(eOmc_encoder_t encoder)
         case eomc_enc_mais:    
         case eomc_enc_qenc:
         case eomc_enc_hallmotor: 
-        case eomc_enc_amo: 
+        case eomc_enc_amo:
+        case eomc_enc_aksim2:
         {
             ret = 1;
         } break;

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -1118,12 +1118,13 @@ typedef enum
     eomc_enc_psc            = 10,
     eomc_enc_pos            = 11,
     eomc_enc_aea3           = 12,
+    eomc_enc_aksim2         = 13,
     
     eomc_enc_none           = 0,
     eomc_enc_unknown        = 255    
 } eOmc_encoder_t;
 
-enum { eomc_encoders_numberof = 12 };
+enum { eomc_encoders_numberof = 13 };
 enum { eomc_encoders_maxnumberofcomponents = 4 };
 
 


### PR DESCRIPTION
What's new:

- Include `eomc_enc_aksim2` in `eOmc_encoder_t` to recognize the new AksIM2 from both `icub-main` and `icub-firmware`.
- Fix/Update the support for J5_XY connectors for `AMC` board

**Notes**
- none

