### PR TITLE
Added the POS service w/ mtb4fap

### DIFF
--- a/can/canProtocolLib/iCubCanProto_types.h
+++ b/can/canProtocolLib/iCubCanProto_types.h
@@ -601,9 +601,23 @@ typedef struct
 
 typedef enum 
 { 
+    icubCanProto_pos_chipid_one         = 0,    
+    icubCanProto_pos_chipid_two         = 1, 
+    icubCanProto_pos_chipid_three       = 2,  
+    icubCanProto_pos_chipid_four        = 3,  
+    icubCanProto_pos_chipid_five        = 4, 
+    icubCanProto_pos_chipid_six         = 5,  
+    icubCanProto_pos_chipid_seven       = 6,
+    icubCanProto_pos_chipid_eigth       = 7,      
+    icubCanProto_pos_chipid_all         = 15 
+} icubCanProto_pos_chipid_t;
+
+typedef enum 
+{ 
     icubCanProto_pos_decideg            = 0,    // it is an angle expressed in 0.1 degrees and contained inside a int16_t 
     icubCanProto_pos_decimillimeter     = 1,    // it is a linear displacement expressed in 0.1 mm and contained inside a int16_t [+/- 3276 mm]
-    icubCanProto_pos_unkwown            = 255 
+    icubCanProto_pos_none               = 14,    
+    icubCanProto_pos_unkwown            = 15 
 } icubCanProto_pos_sensor_t;
 
 typedef enum 
@@ -630,8 +644,9 @@ typedef union
 } icubCanProto_pos_setting_t;
 
 typedef struct
-{   
-    icubCanProto_pos_sensor_t   type;               
+{ 
+    icubCanProto_pos_chipid_t   id;        
+    icubCanProto_pos_sensor_t   type;
     icubCanProto_pos_setting_t  setting;
 } icubCanProto_POS_CONFIG_t;
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -111,7 +111,7 @@ static const eOmap_str_str_u08_t s_boards_map_of_posrots[] =
     {"zero", "eoas_pos_ROT_zero", eoas_pos_ROT_zero},
     {"plus180", "eoas_pos_ROT_plus180", eoas_pos_ROT_plus180},
     {"plus090", "eoas_pos_ROT_plus090", eoas_pos_ROT_plus090},
-    {"minus180", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090},
+    {"minus090", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090},
     
     {"none", "eoas_pos_ROT_none", eoas_pos_ROT_none},
     {"unknown", "eoas_pos_ROT_unknown", eoas_pos_ROT_unknown}   

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -218,8 +218,8 @@ extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot, eObool_t usecompac
 extern eoas_pos_ROT_t eoas_string2posrot(const char * string, eObool_t usecompactstring)
 {    
     const eOmap_str_str_u08_t * map = s_boards_map_of_posrots;
-    const uint8_t size = eoas_pos_ROT_numberof;
-    const uint8_t defvalue = eoas_pos_ROT_zero;
+    const uint8_t size = eoas_pos_ROT_numberof+2;
+    const uint8_t defvalue = eoas_pos_ROT_unknown;
     
     return((eoas_pos_ROT_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));    
 }

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -98,6 +98,25 @@ static const char * s_eoas_sensors_string_unknown = "eoas_unknown";
 static const char * s_eoas_sensors_string_none = "eoas_none";
 
 
+static const char * s_eoas_postype_strings[] =
+{
+    "eoas_pos_TYPE_decideg"
+};  EO_VERIFYsizeof(s_eoas_postype_strings, eoas_pos_TYPE_numberof*sizeof(const char *));    
+
+static const char * s_eoas_postype_string_unknown = "eoas_pos_TYPE_unknown";
+static const char * s_eoas_postype_string_none = "eoas_pos_TYPE__none";
+
+
+static const char * s_eoas_posrot_strings[] =
+{
+    "eoas_pos_ROT_zero",
+    "eoas_pos_ROT_plus180",
+    "eoas_pos_ROT_plus090",
+    "eoas_pos_ROT_minus180"
+};  EO_VERIFYsizeof(s_eoas_posrot_strings, eoas_pos_ROT_numberof*sizeof(const char *));    
+
+static const char * s_eoas_posrot_string_zero = "eoas_pos_ROT_zero";
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
 // --------------------------------------------------------------------------------------------------------------------
@@ -151,6 +170,86 @@ extern eOas_sensor_t eoas_string2sensor(const char * string)
     
     return(eoas_unknown);    
 }
+
+
+
+extern const char * eoas_postype2string(eoas_pos_TYPE_t postype)
+{
+    const char * ret = s_eoas_postype_string_unknown;
+    
+    if(postype < eoas_pos_TYPE_numberof)
+    {
+        return(s_eoas_postype_strings[postype]);
+    }
+    else if(eoas_pos_TYPE_none == postype)
+    {
+        return(s_eoas_postype_string_none);
+    }
+
+
+    return(ret);
+}
+
+
+extern eoas_pos_TYPE_t eoas_string2postype(const char * string)
+{    
+    uint8_t i = 0;
+    if(NULL == string)
+    {
+        return(eoas_pos_TYPE_unknown);
+    }
+    
+    for(i=0; i<eoas_pos_TYPE_numberof; i++)
+    {
+        if(0 == strcmp(string, s_eoas_postype_strings[i]))
+        {
+            return((eoas_pos_TYPE_t)(i+0));
+        }
+    }
+    
+    if(0 == strcmp(string, s_eoas_postype_string_none))
+    {
+        return(eoas_pos_TYPE_none);
+    }        
+    
+    return(eoas_pos_TYPE_unknown);    
+}
+
+
+extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot)
+{
+    const char * ret = s_eoas_posrot_string_zero;
+    
+    if(posrot < eoas_pos_ROT_numberof)
+    {
+        return(s_eoas_posrot_strings[posrot]);
+    }
+
+    return(ret);
+}
+
+
+extern eoas_pos_ROT_t eoas_string2posrot(const char * string)
+{    
+    uint8_t i = 0;
+    if(NULL == string)
+    {
+        return(eoas_pos_ROT_zero);
+    }
+    
+    for(i=0; i<eoas_pos_ROT_numberof; i++)
+    {
+        if(0 == strcmp(string, s_eoas_posrot_strings[i]))
+        {
+            return((eoas_pos_ROT_t)(i+0));
+        }
+    }     
+    
+    return(eoas_pos_ROT_zero);    
+}
+
+
+
 
 enum { in3_mtb_pos = 0, in3_mtb4_pos = 1, in3_strain2_pos = 2, in3_rfe_pos = 3, in3_mtb4c_pos = 4 };
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -94,28 +94,26 @@ static const char * s_eoas_sensors_strings[] =
 
 
 static const char * s_eoas_sensors_string_unknown = "eoas_unknown";
-
 static const char * s_eoas_sensors_string_none = "eoas_none";
 
 
-static const char * s_eoas_postype_strings[] =
+static const eOmap_str_str_u08_t s_boards_map_of_postypes[] =
 {
-    "eoas_pos_TYPE_decideg"
-};  EO_VERIFYsizeof(s_eoas_postype_strings, eoas_pos_TYPE_numberof*sizeof(const char *));    
+    {"decideg", "eoas_pos_TYPE_decideg", eoas_pos_TYPE_decideg},
 
-static const char * s_eoas_postype_string_unknown = "eoas_pos_TYPE_unknown";
-static const char * s_eoas_postype_string_none = "eoas_pos_TYPE__none";
+    {"none", "eoas_pos_TYPE_none", eoas_pos_TYPE_none},
+    {"unknown", "eoas_pos_TYPE_unknown", eoas_pos_TYPE_unknown}    
+};  EO_VERIFYsizeof(s_boards_map_of_postypes, (eoas_pos_TYPE_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
-static const char * s_eoas_posrot_strings[] =
+static const eOmap_str_str_u08_t s_boards_map_of_posrots[] =
 {
-    "eoas_pos_ROT_zero",
-    "eoas_pos_ROT_plus180",
-    "eoas_pos_ROT_plus090",
-    "eoas_pos_ROT_minus180"
-};  EO_VERIFYsizeof(s_eoas_posrot_strings, eoas_pos_ROT_numberof*sizeof(const char *));    
-
-static const char * s_eoas_posrot_string_zero = "eoas_pos_ROT_zero";
+    {"zero", "eoas_pos_ROT_zero", eoas_pos_ROT_zero},
+    {"plus180", "eoas_pos_ROT_plus180", eoas_pos_ROT_plus180},
+    {"plus090", "eoas_pos_ROT_plus090", eoas_pos_ROT_plus090},
+    {"minus180", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090} 
+    
+};  EO_VERIFYsizeof(s_boards_map_of_posrots, (eoas_pos_ROT_numberof)*sizeof(eOmap_str_str_u08_t))
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
@@ -173,79 +171,55 @@ extern eOas_sensor_t eoas_string2sensor(const char * string)
 
 
 
-extern const char * eoas_postype2string(eoas_pos_TYPE_t postype)
-{
-    const char * ret = s_eoas_postype_string_unknown;
-    
-    if(postype < eoas_pos_TYPE_numberof)
-    {
-        return(s_eoas_postype_strings[postype]);
-    }
-    else if(eoas_pos_TYPE_none == postype)
-    {
-        return(s_eoas_postype_string_none);
-    }
-
-
-    return(ret);
-}
-
-
-extern eoas_pos_TYPE_t eoas_string2postype(const char * string)
+extern const char * eoas_postype2string(eoas_pos_TYPE_t postype, eObool_t usecompactstring)
 {    
-    uint8_t i = 0;
-    if(NULL == string)
+    const eOmap_str_str_u08_t * map = s_boards_map_of_postypes;
+    const uint8_t size = eoas_pos_TYPE_numberof+2;
+    const uint8_t value = postype;
+    const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
+    
+    if(NULL == str)
     {
-        return(eoas_pos_TYPE_unknown);
+        str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
     
-    for(i=0; i<eoas_pos_TYPE_numberof; i++)
-    {
-        if(0 == strcmp(string, s_eoas_postype_strings[i]))
-        {
-            return((eoas_pos_TYPE_t)(i+0));
-        }
-    }
-    
-    if(0 == strcmp(string, s_eoas_postype_string_none))
-    {
-        return(eoas_pos_TYPE_none);
-    }        
-    
-    return(eoas_pos_TYPE_unknown);    
+    return(str); 
 }
 
 
-extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot)
-{
-    const char * ret = s_eoas_posrot_string_zero;
-    
-    if(posrot < eoas_pos_ROT_numberof)
-    {
-        return(s_eoas_posrot_strings[posrot]);
-    }
-
-    return(ret);
-}
-
-
-extern eoas_pos_ROT_t eoas_string2posrot(const char * string)
+extern eoas_pos_TYPE_t eoas_string2postype(const char * string, eObool_t usecompactstring)
 {    
-    uint8_t i = 0;
-    if(NULL == string)
+    const eOmap_str_str_u08_t * map = s_boards_map_of_postypes;
+    const uint8_t size = eoas_pos_TYPE_numberof+2;
+    const uint8_t defvalue = eoas_pos_TYPE_unknown;
+    
+    return((eoas_pos_TYPE_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));     
+}
+
+extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot, eObool_t usecompactstring)
+{
+    const eOmap_str_str_u08_t * map = s_boards_map_of_posrots;
+    const uint8_t size = eoas_pos_ROT_numberof;
+    const uint8_t value = posrot;
+    const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
+    
+    if(NULL == str)
     {
-        return(eoas_pos_ROT_zero);
+        const uint8_t defaultvalueindex = 0; // zero
+        str = (eobool_true == usecompactstring) ? (map[defaultvalueindex].str0) : (map[defaultvalueindex].str1);
     }
     
-    for(i=0; i<eoas_pos_ROT_numberof; i++)
-    {
-        if(0 == strcmp(string, s_eoas_posrot_strings[i]))
-        {
-            return((eoas_pos_ROT_t)(i+0));
-        }
-    }     
+    return(str);
+}
+
+
+extern eoas_pos_ROT_t eoas_string2posrot(const char * string, eObool_t usecompactstring)
+{    
+    const eOmap_str_str_u08_t * map = s_boards_map_of_posrots;
+    const uint8_t size = eoas_pos_ROT_numberof;
+    const uint8_t defvalue = eoas_pos_ROT_zero;
     
-    return(eoas_pos_ROT_zero);    
+    return((eoas_pos_ROT_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));    
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -111,9 +111,12 @@ static const eOmap_str_str_u08_t s_boards_map_of_posrots[] =
     {"zero", "eoas_pos_ROT_zero", eoas_pos_ROT_zero},
     {"plus180", "eoas_pos_ROT_plus180", eoas_pos_ROT_plus180},
     {"plus090", "eoas_pos_ROT_plus090", eoas_pos_ROT_plus090},
-    {"minus180", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090} 
+    {"minus180", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090},
     
-};  EO_VERIFYsizeof(s_boards_map_of_posrots, (eoas_pos_ROT_numberof)*sizeof(eOmap_str_str_u08_t))
+    {"none", "eoas_pos_ROT_none", eoas_pos_ROT_none},
+    {"unknown", "eoas_pos_ROT_unknown", eoas_pos_ROT_unknown}   
+    
+};  EO_VERIFYsizeof(s_boards_map_of_posrots, (eoas_pos_ROT_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
@@ -199,14 +202,13 @@ extern eoas_pos_TYPE_t eoas_string2postype(const char * string, eObool_t usecomp
 extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot, eObool_t usecompactstring)
 {
     const eOmap_str_str_u08_t * map = s_boards_map_of_posrots;
-    const uint8_t size = eoas_pos_ROT_numberof;
+    const uint8_t size = eoas_pos_ROT_numberof+2;
     const uint8_t value = posrot;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
     
     if(NULL == str)
     {
-        const uint8_t defaultvalueindex = 0; // zero
-        str = (eobool_true == usecompactstring) ? (map[defaultvalueindex].str0) : (map[defaultvalueindex].str1);
+        str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
     
     return(str);

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -632,7 +632,9 @@ typedef enum
     eoas_pos_ROT_zero = 0,
     eoas_pos_ROT_plus180 = 1,
     eoas_pos_ROT_plus090 = 2,
-    eoas_pos_ROT_minus090 = 3        
+    eoas_pos_ROT_minus090 = 3,
+    eoas_pos_ROT_none = 14,
+    eoas_pos_ROT_unknown = 15,
 } eoas_pos_ROT_t;
 enum { eoas_pos_ROT_numberof = 4 };
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -869,11 +869,11 @@ extern uint8_t eoas_battery_supportedboards_numberof(void);
 extern eObrd_cantype_t eoas_battery_supportedboards_gettype(uint8_t pos);
 extern eObool_t eoas_battery_isboardvalid(eObrd_cantype_t boardtype);
 
-extern const char * eoas_postype2string(eoas_pos_TYPE_t postype);
-extern eoas_pos_TYPE_t eoas_string2postype(const char * string);
+extern const char * eoas_postype2string(eoas_pos_TYPE_t postype, eObool_t usecompactstring);
+extern eoas_pos_TYPE_t eoas_string2postype(const char * string, eObool_t usecompactstring);
 
-extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot);
-extern eoas_pos_ROT_t eoas_string2posrot(const char * string);
+extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot, eObool_t usecompactstring);
+extern eoas_pos_ROT_t eoas_string2posrot(const char * string, eObool_t usecompactstring);
 
 
 /** @}

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -634,6 +634,35 @@ typedef struct
     eObrd_canlocation_t                 canloc[eOas_pos_boards_maxnumber];
 } eOas_pos_canLocationsInfo_t;
 
+
+typedef struct
+{
+    uint16_t id                 : 4; // id on the board (0, 1, 2, ...)
+    uint16_t type               : 4; // only icubCanProto_pos_decideg = 0 
+    uint16_t label              : 4; // 0, 1, 2, 
+    uint16_t enabled            : 1; // if 1 is enabled
+    uint16_t invertdirection    : 1;
+    uint16_t rotation           : 2; // icubCanProto_pos_rot_t
+    int16_t  zero;                   // in decideg
+} eoas_pos_SensorConfig_t; EO_VERIFYsizeof(eoas_pos_SensorConfig_t, 4)
+
+//#warning change icubCanProto_pos_unkwown to have 4 bits range
+
+enum { eOas_pos_sensorsinboard_maxnumber = 4 };
+
+typedef struct
+{
+    eObrd_info_t            boardinfo;
+    eObrd_canlocation_t     canloc;
+    uint8_t                 filler[1];
+    eoas_pos_SensorConfig_t sensors[eOas_pos_sensorsinboard_maxnumber];   
+} eoas_pos_BoardConfig_t; EO_VERIFYsizeof(eoas_pos_BoardConfig_t, 24)
+
+typedef struct
+{
+    eoas_pos_BoardConfig_t boardconfig[eOas_pos_boards_maxnumber];
+} eoas_pos_ServiceConfig_t; EO_VERIFYsizeof(eoas_pos_ServiceConfig_t, 24)
+
 // a single pos sensor contains an angle expressed in deci-degrees 
 // this struct describes the data acquired by a single pos sensor
 typedef struct

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -615,40 +615,44 @@ typedef struct                      // size is: 4+16+4 = 24
 
 // -- the definition of a pos sensor service
 
-// we use this struct to send activate-verify command to the board
-//enum { eOas_pos_boardinfos_maxnumber = 4 };
-//typedef struct
-//{   //6*4=24
-//    eObrd_info_t                    data[eOas_pos_boardinfos_maxnumber];
-//} eOas_pos_setof_boardinfos_t; EO_VERIFYsizeof(eOas_pos_setof_boardinfos_t, 24)
-
-//enum { eOas_pos_boards_maxnumber = 3 };
-//typedef struct
-//{
-//    eObrd_canproperties_t           canprop[eOas_pos_boards_maxnumber];
-//} eOas_pos_canPropertiesInfo_t;
-
+// we can have at most 1 CAN board for the POS service each with at most 4 sensors in it
 enum { eOas_pos_boards_maxnumber = 1 };
+enum { eOas_pos_sensorsinboard_maxnumber = 4 };
+
+typedef enum
+{
+    eoas_pos_TYPE_decideg = 0,
+    eoas_pos_TYPE_none = 14,
+    eoas_pos_TYPE_unknown = 15    
+} eoas_pos_TYPE_t;
+enum { eoas_pos_TYPE_numberof = 1 };
+
+typedef enum
+{
+    eoas_pos_ROT_zero = 0,
+    eoas_pos_ROT_plus180 = 1,
+    eoas_pos_ROT_plus090 = 2,
+    eoas_pos_ROT_minus090 = 3        
+} eoas_pos_ROT_t;
+enum { eoas_pos_ROT_numberof = 4 };
+
+// each sensor on the board is identified by:
+// - a type which specifies the nature of the quantity read by the sensor. so far we only have eoas_pos_TYPE_decideg, so rotational angle expressed in 0.1 deg
+// - a connector to which the sensor is attached in the board or the embot::hw::ID of the relevant device
+// - a port to which its reading is associated in the CAN protocol (via its label filed) so that we can understand if it is a POS:hand_thumb or POS:hand_index
+// - a boolean telling if the sensor is enabled or not
+// - some calibration parameters which are used to map the decideg reading in a valid range without zero crossing
 typedef struct
 {
-    eObrd_canlocation_t                 canloc[eOas_pos_boards_maxnumber];
-} eOas_pos_canLocationsInfo_t;
-
-
-typedef struct
-{
-    uint16_t id                 : 4; // id on the board (0, 1, 2, ...)
-    uint16_t type               : 4; // only icubCanProto_pos_decideg = 0 
-    uint16_t label              : 4; // 0, 1, 2, 
+    uint16_t type               : 4; // use eoas_pos_TYPE_t 
+    uint16_t connector          : 4; // connector on the board (0, 1, 2, ...) or id of the embot::hw device
+    uint16_t port               : 4; // [0, 1, ..., 15], BUT: use values such as POS:hand_thumb taken from eObrd_portpos_t
     uint16_t enabled            : 1; // if 1 is enabled
     uint16_t invertdirection    : 1;
-    uint16_t rotation           : 2; // icubCanProto_pos_rot_t
+    uint16_t rotation           : 2; // use eoas_pos_ROT_t except for eoas_pos_ROT_unknown
     int16_t  zero;                   // in decideg
 } eoas_pos_SensorConfig_t; EO_VERIFYsizeof(eoas_pos_SensorConfig_t, 4)
 
-//#warning change icubCanProto_pos_unkwown to have 4 bits range
-
-enum { eOas_pos_sensorsinboard_maxnumber = 4 };
 
 typedef struct
 {
@@ -864,6 +868,12 @@ extern eObool_t eoas_ft_isboardvalid(eObrd_cantype_t boardtype);
 extern uint8_t eoas_battery_supportedboards_numberof(void);
 extern eObrd_cantype_t eoas_battery_supportedboards_gettype(uint8_t pos);
 extern eObool_t eoas_battery_isboardvalid(eObrd_cantype_t boardtype);
+
+extern const char * eoas_postype2string(eoas_pos_TYPE_t postype);
+extern eoas_pos_TYPE_t eoas_string2postype(const char * string);
+
+extern const char * eoas_posrot2string(eoas_pos_ROT_t posrot);
+extern eoas_pos_ROT_t eoas_string2posrot(const char * string);
 
 
 /** @}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -158,6 +158,10 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"J3_SDA1", "eobrd_conn_J3_SDA1", eobrd_conn_J3_SDA1},
     {"J3_SDA2", "eobrd_conn_J3_SDA2", eobrd_conn_J3_SDA2},
     {"J3_SDA3", "eobrd_conn_J3_SDA3", eobrd_conn_J3_SDA3},
+    {"J4", "eobrd_conn_J4", eobrd_conn_J4},
+    {"J5", "eobrd_conn_J5", eobrd_conn_J5},
+    {"J6", "eobrd_conn_J6", eobrd_conn_J6},
+    {"J7", "eobrd_conn_J7", eobrd_conn_J7},
     
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
@@ -189,10 +193,15 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
     {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
     
-    {"mtb4fap_J3_SDA0", "eobrd_portmtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
-    {"mtb4fap_J3_SDA1", "eobrd_portmtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
-    {"mtb4fap_J3_SDA2", "eobrd_portmtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
-    {"mtb4fap_J3_SDA3", "eobrd_portmtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
+    {"mtb4fap_J3_SDA0", "eobrd_port_mtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
+    {"mtb4fap_J3_SDA1", "eobrd_port_mtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
+    {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
+    {"mtb4fap_J3_SDA3", "eobrd_port_mtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
+
+    {"pmc_J4", "eobrd_port_pmc_J4", eobrd_port_pmc_J4, eobrd_pmc, eobrd_conn_J4},
+    {"pmc_J5", "eobrd_port_pmc_J5", eobrd_port_pmc_J5, eobrd_pmc, eobrd_conn_J5},
+    {"pmc_J6", "eobrd_port_pmc_J6", eobrd_port_pmc_J6, eobrd_pmc, eobrd_conn_J6},
+    {"pmc_J7", "eobrd_port_pmc_J7", eobrd_port_pmc_J7, eobrd_pmc, eobrd_conn_J7},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -154,6 +154,10 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"J5_X1", "eobrd_conn_J5_X1", eobrd_conn_J5_X1},
     {"J5_X2", "eobrd_conn_J5_X2", eobrd_conn_J5_X2},
     {"J5_X3", "eobrd_conn_J5_X3", eobrd_conn_J5_X3},
+    {"J3_SDA0", "eobrd_conn_J3_SDA0", eobrd_conn_J3_SDA0},
+    {"J3_SDA1", "eobrd_conn_J3_SDA1", eobrd_conn_J3_SDA1},
+    {"J3_SDA2", "eobrd_conn_J3_SDA2", eobrd_conn_J3_SDA2},
+    {"J3_SDA3", "eobrd_conn_J3_SDA3", eobrd_conn_J3_SDA3},
     
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
@@ -184,6 +188,11 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"amcJ5_X1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
     {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
     {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
+    
+    {"mtb4fap_J3_SDA0", "eobrd_portmtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
+    {"mtb4fap_J3_SDA1", "eobrd_portmtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
+    {"mtb4fap_J3_SDA2", "eobrd_portmtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
+    {"mtb4fap_J3_SDA3", "eobrd_portmtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -295,14 +295,18 @@ typedef enum
     eobrd_conn_P13  = 13,
     eobrd_conn_P14  = 14,
     eobrd_conn_P15  = 15,
-    eobrd_conn_J5_X1  = 16,
-    eobrd_conn_J5_X2  = 17,
-    eobrd_conn_J5_X3  = 18,
-    eobrd_conn_none = 0,
-    eobrd_conn_unknown = 255
+    eobrd_conn_J5_X1    = 16,
+    eobrd_conn_J5_X2    = 17,
+    eobrd_conn_J5_X3    = 18,
+    eobrd_conn_J3_SDA0  = 19,
+    eobrd_conn_J3_SDA1  = 20,
+    eobrd_conn_J3_SDA2  = 21,
+    eobrd_conn_J3_SDA3  = 22,
+    eobrd_conn_none     = 0,
+    eobrd_conn_unknown  = 255
 } eObrd_connector_t;
 
-enum { eobrd_connectors_numberof = 18 };
+enum { eobrd_connectors_numberof = 22 };
 
 
 typedef enum
@@ -330,13 +334,18 @@ typedef enum
     eobrd_port_mc2plusP10           = 0,        // SPI encoder: hal_encoder1
     eobrd_port_mc2plusP11           = 1,        // SPI encoder: hal_encoder2   
 
-    eobrd_port_amc_J5_X1                = 0,        // SPI encoder: embot::hw::encoder1
-    eobrd_port_amc_J5_X2                = 1,        // SPI encoder: embot::hw::encoder2
-    eobrd_port_amc_J5_X3                = 2,        // SPI encoder: embot::hw::encoder3
+    eobrd_port_amc_J5_X1            = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amc_J5_X2            = 1,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amc_J5_X3            = 2,        // SPI encoder: embot::hw::encoder3
 
+    eobrd_port_mtb4fap_J3_SDA0      = 0,
+    eobrd_port_mtb4fap_J3_SDA1      = 1,
+    eobrd_port_mtb4fap_J3_SDA2      = 2,
+    eobrd_port_mtb4fap_J3_SDA3      = 3    
+    
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 19 };
+enum { eobrd_ports_numberof = 23 };
 
 
 typedef enum

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -280,21 +280,21 @@ typedef struct
  **/
 typedef enum
 {
-    eobrd_conn_P1   = 1,
-    eobrd_conn_P2   = 2,
-    eobrd_conn_P3   = 3,
-    eobrd_conn_P4   = 4,
-    eobrd_conn_P5   = 5,
-    eobrd_conn_P6   = 6,
-    eobrd_conn_P7   = 7,
-    eobrd_conn_P8   = 8,
-    eobrd_conn_P9   = 9,
-    eobrd_conn_P10  = 10,
-    eobrd_conn_P11  = 11,
-    eobrd_conn_P12  = 12,
-    eobrd_conn_P13  = 13,
-    eobrd_conn_P14  = 14,
-    eobrd_conn_P15  = 15,
+    eobrd_conn_P1       = 1,
+    eobrd_conn_P2       = 2,
+    eobrd_conn_P3       = 3,
+    eobrd_conn_P4       = 4,
+    eobrd_conn_P5       = 5,
+    eobrd_conn_P6       = 6,
+    eobrd_conn_P7       = 7,
+    eobrd_conn_P8       = 8,
+    eobrd_conn_P9       = 9,
+    eobrd_conn_P10      = 10,
+    eobrd_conn_P11      = 11,
+    eobrd_conn_P12      = 12,
+    eobrd_conn_P13      = 13,
+    eobrd_conn_P14      = 14,
+    eobrd_conn_P15      = 15,
     eobrd_conn_J5_X1    = 16,
     eobrd_conn_J5_X2    = 17,
     eobrd_conn_J5_X3    = 18,
@@ -302,11 +302,16 @@ typedef enum
     eobrd_conn_J3_SDA1  = 20,
     eobrd_conn_J3_SDA2  = 21,
     eobrd_conn_J3_SDA3  = 22,
+    eobrd_conn_J4       = 23,
+    eobrd_conn_J5       = 24,
+    eobrd_conn_J6       = 25,
+    eobrd_conn_J7       = 26,   
+    
     eobrd_conn_none     = 0,
     eobrd_conn_unknown  = 255
 } eObrd_connector_t;
 
-enum { eobrd_connectors_numberof = 22 };
+enum { eobrd_connectors_numberof = 26 };
 
 
 typedef enum
@@ -341,11 +346,16 @@ typedef enum
     eobrd_port_mtb4fap_J3_SDA0      = 0,
     eobrd_port_mtb4fap_J3_SDA1      = 1,
     eobrd_port_mtb4fap_J3_SDA2      = 2,
-    eobrd_port_mtb4fap_J3_SDA3      = 3    
+    eobrd_port_mtb4fap_J3_SDA3      = 3,  
+    
+    eobrd_port_pmc_J4               = 0,        // I2C1 
+    eobrd_port_pmc_J5               = 1,        // I2C2
+    eobrd_port_pmc_J6               = 2,        // I2C3
+    eobrd_port_pmc_J7               = 3         // I2C4 
     
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 23 };
+enum { eobrd_ports_numberof = 27 };
 
 
 typedef enum

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -334,7 +334,7 @@ const eoerror_valuestring_t eoerror_valuestrings_CFG[] =
 
     {eoerror_value_CFG_mc_mc4plusfaps_ok, "CFG: EOtheMotionController can correctly configure mc4plusfaps-based motion. more info will follow"},
     {eoerror_value_CFG_mc_mc4plusfaps_failed_encoders_verify, "CFG: EOtheMotionController cannot be configured. verification of encoder fails for mc4plusfaps. see other messages for more details"},
-    {eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery_of_pmc, "CFG: EOtheMotionController cannot be configured. verification of pos for mc4plusfaps fails. see other messages for more details"},
+    {eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery, "CFG: EOtheMotionController cannot be configured. verification of pos for mc4plusfaps fails. see other messages for more details"},
  
     {eoerror_value_CFG_mc_mc4pluspmc_ok, "CFG: EOtheMotionController can correctly configure mc4pluspmc-based motion. more info will follow"},
     {eoerror_value_CFG_mc_mc4pluspmc_failed_encoders_verify, "CFG: EOtheMotionController cannot be configured. verification of encoder fails for mc4pluspmc. see other messages for more details"},

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -387,7 +387,7 @@ typedef enum
     
     eoerror_value_CFG_mc_mc4plusfaps_ok                 = 84,
     eoerror_value_CFG_mc_mc4plusfaps_failed_encoders_verify = 85, 
-    eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery_of_pmc = 86,    
+    eoerror_value_CFG_mc_mc4plusfaps_failed_candiscovery = 86,    
 
     eoerror_value_CFG_mc_mc4pluspmc_ok                 = 87,
     eoerror_value_CFG_mc_mc4pluspmc_failed_encoders_verify = 88, 

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -535,9 +535,8 @@ typedef struct
 
 typedef struct
 {   
-    eObrd_version_t                     version;
-    eOas_pos_canLocationsInfo_t         boardInfo;
-} eOmn_serv_config_data_as_pos_t;       EO_VERIFYsizeof(eOmn_serv_config_data_as_pos_t, 6)
+    eoas_pos_ServiceConfig_t            config;
+} eOmn_serv_config_data_as_pos_t;       EO_VERIFYsizeof(eOmn_serv_config_data_as_pos_t, 24)
 
 
 typedef struct
@@ -553,7 +552,7 @@ typedef struct
 } eOmn_serv_config_data_as_battery_t;        EO_VERIFYsizeof(eOmn_serv_config_data_as_battery_t, 16)
 
 typedef union
-{   // max(6, 6, 44, 108, 162, 8, 6, 40)
+{   // max(6, 6, 44, 108, 162, 8, 24, 40, 16)
     eOmn_serv_config_data_as_mais_t         mais;
     eOmn_serv_config_data_as_strain_t       strain;
     eOmn_serv_config_data_as_temperature_t  temperature;
@@ -635,25 +634,23 @@ typedef struct
 
 
 typedef struct
-{   // 6+2+24+292=324
+{   // 24+24+292=340
     eOmn_serv_config_data_as_pos_t          pos;
-    uint8_t                                 filler[2];
     eOmc_arrayof_4jomodescriptors_t         arrayofjomodescriptors;  
     eOmc_4jomo_coupling_t                   jomocoupling;
-} eOmn_serv_config_data_mc_mc4plusfaps_t;   EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc4plusfaps_t, 324)
+} eOmn_serv_config_data_mc_mc4plusfaps_t;   EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc4plusfaps_t, 340)
 
 // we have 4 dc joints moved by the mc4plus + 3 joints moved by pmc. all of them are independent
 typedef struct
-{   // 6 + 2 + 39 + 1 + 116 = 164
+{   // 24 + 39 + 1 + 116 = 180
     eOmn_serv_config_data_as_pos_t          pos;
-    uint8_t                                 filler[2];
     eOmc_arrayof_7jomodescriptors_t         arrayof7jomodescriptors;  
     uint8_t                                 dummy[1];
     eOmc_arrayof_7jointsetconfig_t          arrayof7jointsets;
-} eOmn_serv_config_data_mc_mc4pluspmc_t;    EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc4pluspmc_t, 164)
+} eOmn_serv_config_data_mc_mc4pluspmc_t;    EO_VERIFYsizeof(eOmn_serv_config_data_mc_mc4pluspmc_t, 180)
 
 typedef union                               
-{   // max(324, 28, 316, 328, 324, 47)
+{   // max(324, 28, 316, 328, 340, 180)
     eOmn_serv_config_data_mc_foc_t          foc_based;
     eOmn_serv_config_data_mc_mc4_t          mc4_based;
     eOmn_serv_config_data_mc_mc4plus_t      mc4plus_based;
@@ -662,23 +659,23 @@ typedef union
     eOmn_serv_config_data_mc_mc2pluspsc_t   mc2pluspsc;
     eOmn_serv_config_data_mc_mc4plusfaps_t  mc4plusfaps;
     eOmn_serv_config_data_mc_mc4pluspmc_t   mc4pluspmc;
-} eOmn_serv_config_data_mc_t;               EO_VERIFYsizeof(eOmn_serv_config_data_mc_t, 328) 
+} eOmn_serv_config_data_mc_t;               EO_VERIFYsizeof(eOmn_serv_config_data_mc_t, 340) 
 
 typedef union                               
-{   // max(156, 324, 24)
+{   // max(156, 340, 24)
     eOmn_serv_config_data_as_t              as;
     eOmn_serv_config_data_mc_t              mc;
     eOmn_serv_config_data_sk_t              sk;   
-} eOmn_serv_config_data_t;                  EO_VERIFYsizeof(eOmn_serv_config_data_t, 328) 
+} eOmn_serv_config_data_t;                  EO_VERIFYsizeof(eOmn_serv_config_data_t, 340) 
 
 
 typedef struct                              
-{   // 1+3+324=328
+{   // 1+3+340=344
     uint8_t                                 type;               // use eOmn_serv_type_t to identify what kind of service it is
     uint8_t                                 diagnosticsmode;    // use eOmn_serv_diagn_mode_t
     uint16_t                                diagnosticsparam;   // i cannot fit eOmn_serv_diagn_cfg_t inside here because of alignment and i want to keep backwards compatibility
     eOmn_serv_config_data_t                 data;   
-} eOmn_serv_configuration_t;                EO_VERIFYsizeof(eOmn_serv_configuration_t, 332) 
+} eOmn_serv_configuration_t;                EO_VERIFYsizeof(eOmn_serv_configuration_t, 344) 
 
 enum { eOmn_serv_capacity_arrayof_id32 = 41 };
 typedef struct
@@ -717,25 +714,25 @@ typedef enum
 
 
 typedef union
-{  //max( 328, 168)
+{  //max( 344, 168)
     eOmn_serv_configuration_t   configuration;
     eOmn_serv_arrayof_id32_t    arrayofid32;
-} eOmn_serv_parameter_t;
+} eOmn_serv_parameter_t; EO_VERIFYsizeof(eOmn_serv_parameter_t, 344)
 
 
 typedef struct                                
-{   // 1+3+328=304
+{   // 1+1+2+344=348
     uint8_t                                 operation;              // use eOmn_serv_operation_t
     uint8_t                                 category;               // use eOmn_serv_category_t
     uint8_t                                 filler[2];
     eOmn_serv_parameter_t                   parameter;
-} eOmn_service_cmmnds_command_t;            EO_VERIFYsizeof(eOmn_service_cmmnds_command_t, 336)
+} eOmn_service_cmmnds_command_t;            EO_VERIFYsizeof(eOmn_service_cmmnds_command_t, 348)
 
 
 typedef struct
-{   // 332
+{   // 348
     eOmn_service_cmmnds_command_t           command;    
-} eOmn_service_cmmnds_t;                    EO_VERIFYsizeof(eOmn_service_cmmnds_t, 336)
+} eOmn_service_cmmnds_t;                    EO_VERIFYsizeof(eOmn_service_cmmnds_t, 348)
 
 
 typedef struct
@@ -769,11 +766,11 @@ typedef struct
     @brief      used to represent the info with config, status
  **/
 typedef struct                      
-{   // 48+336=372    
+{   // 48+348=396    
     eOmn_service_status_t                   status;
     eOmn_service_cmmnds_t                   cmmnds;
-} eOmn_service_t;                           EO_VERIFYsizeof(eOmn_service_t, 384)  
-//char (*luca)[sizeof( eOmn_service_t )] = 1;
+} eOmn_service_t;                           EO_VERIFYsizeof(eOmn_service_t, 396)  
+
 
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------
 // empty-section

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocol.h
@@ -218,7 +218,7 @@ typedef enum
     eoprot_entity_as_pos                    = eoas_entity_pos,          /**<  */ 
     eoprot_entity_as_ft                     = eoas_entity_ft,           /**<  */      
     eoprot_entity_sk_skin                   = eosk_entity_skin,         /**<  */
-    eoprot_entity_as_battery             = eoas_entity_battery,   /**<  */      
+    eoprot_entity_as_battery                = eoas_entity_battery,      /**<  */      
     eoprot_entity_none                      = EOK_uint08dummy
 } eOprot_entity_t;
 


### PR DESCRIPTION
This PR improves the `POS` service so that we can now use also an `mtb4fap` board (and the `pmc`) and we can impose the calibration parameters in xml files.

