### PR TITLE
`EOtimer`: added dummy implementation of two functions

### DIFF
--- a/eth/embobj/core/core/EOtimer.c
+++ b/eth/embobj/core/core/EOtimer.c
@@ -117,6 +117,28 @@ extern EOtimer* eo_timer_New(void)
     return(retptr);
 }
 
+extern void eo_timer_SetName(EOtimer *t, const char *name) 
+{   
+    if(NULL == t)
+    {
+        return;
+    }
+    
+    if(NULL != name)
+    {
+//        t->name = name;
+    }
+}
+
+extern const char * eo_timer_GetName(EOtimer *t) 
+{   
+    if(NULL == t)
+    {
+        return s_eobj_ownname;
+    }
+    return s_eobj_ownname;    
+//    return t->name;
+}
 
 extern void eo_timer_Delete(EOtimer *t) 
 {   
@@ -313,7 +335,6 @@ extern eOtimerMode_t eo_timer_GetMode(EOtimer *t)
 // - definition of extern hidden functions 
 // --------------------------------------------------------------------------------------------------------------------
 
-
 extern void eo_timer_hid_Reset(EOtimer *t, eOtimerStatus_t stat) 
 {
     uint8_t v = (eo_tmrstat_Idle == stat) ? (EOTIMER_STATUS_IDLE) : 
@@ -331,6 +352,7 @@ extern void eo_timer_hid_Reset(EOtimer *t, eOtimerStatus_t stat)
         t->envir.nextexpiry     = 0;
         memset(&(t->onexpiry), 0, sizeof(EOaction));
         t->onexpiry.actiontype  = eo_actypeNONE;
+//        t->name = s_eobj_ownname;
     }
 }
 

--- a/eth/embobj/core/core/EOtimer.h
+++ b/eth/embobj/core/core/EOtimer.h
@@ -168,6 +168,10 @@ extern eOtimerStatus_t eo_timer_GetStatus(EOtimer *t);
 
 extern eOtimerMode_t eo_timer_GetMode(EOtimer *t);
  
+ 
+extern void eo_timer_SetName(EOtimer *t, const char *name);
+
+extern const char * eo_timer_GetName(EOtimer *t);  
 
 
 /** @}            

--- a/eth/embobj/core/core/EOtimer_hid.h
+++ b/eth/embobj/core/core/EOtimer_hid.h
@@ -76,6 +76,7 @@ struct EOtimer_hid
     uint8_t     initted: 1;
     uint8_t     dummy:  4;          /**< for future use                                        */
     EOaction    onexpiry;           /**< action to be executed on expiry                       */
+    //    const char *name; // marco.accame: dont want to increase memory requirement of EOtimer
 }; 
 
 


### PR DESCRIPTION
Added dummy implementation of two functions for `EOtimer`:

- `eo_timer_SetName(EOtimer *t, const char *name)`
- `const char * eo_timer_GetName(EOtimer *t)`

I need the functions for a PR in `icub-firmware` so that I can track execution of multiple `EOtimer` objects but the functions are dummy, so they do not harm legacy code anywhere.