### PR TITLE
Improved diagnostics for AksIM2 encoder extending existing data structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.30.0)
+        VERSION 1.31.0)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -171,9 +171,13 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
 const eoerror_valuestring_t eoerror_valuestrings_HW[] =
 {   // very important: fill table with order of eOerror_value_HW_t
     //                 in case of holes, use {0, NULL}
-    {eoerror_value_HW_first,                "HW: first error message of category hw"},       
-    {eoerror_value_HW_second,               "HW: second error message of category hw"},
-    {eoerror_value_HW_strain_saturation,    "HW: strain values saturation. In p16 there is the channel involved, in p64 there are the saturation counts for the last sec of both types (lower: LS32bits, upper MS32bits"},
+    {eoerror_value_HW_first,                   "HW: first error message of category hw"},       
+    {eoerror_value_HW_second,                  "HW: second error message of category hw"},
+    {eoerror_value_HW_strain_saturation,       "HW: strain values saturation. In p16 there is the channel involved, in p64 there are the saturation counts for the last sec of both types (lower: LS32bits, upper MS32bits"},
+    {eoerror_value_HW_encoder_invalid_value,   "HW - encoder: the position data is not valid"},
+    {eoerror_value_HW_encoder_close_to_limits, "HW - encoder: the position data is valid, but some operating conditions are close to limits."},
+    {eoerror_value_HW_encoder_crc,             "HW - encoder: inverted CRC is invalid"},
+    {eoerror_value_HW_encoder_not_connected,   "HW - encoder: not connected"}
 };  EO_VERIFYsizeof(eoerror_valuestrings_HW, eoerror_value_HW_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -184,7 +184,7 @@ const eoerror_valuestring_t eoerror_valuestrings_HW[] =
 const eoerror_valuestring_t eoerror_valuestrings_MC[] =
 {   // very important: fill table with order of eOerror_value_MC_t
     //                 in case of holes, use {0, NULL}
-    {eoerror_value_MC_motor_external_fault,  "MC: exernal fault button pressed."},
+    {eoerror_value_MC_motor_external_fault,  "MC: external fault button pressed."},
     {eoerror_value_MC_motor_overcurrent,     "MC: overcurrent. The motor has been turned off to prevent it from being damaged by an impulsive spike of current. par16 = ID of joint."},
     {eoerror_value_MC_motor_i2t_limit,       "MC: i2t limit exceeded. The motor has been turned off to prevent it from being damaged by overheating due to a continuous high current. par16 = ID of joint."},
     {eoerror_value_MC_motor_hallsensors,     "MC: 2FOC hall sensors fault. Invalid sequence in motor Hall effect sensors, please check motor hall cable connections. par16 = ID of joint."},

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -191,12 +191,16 @@ enum { eoerror_value_SYS_numberof = 64 };
  **/
 typedef enum
 {
-    eoerror_value_HW_first             = 0,
-    eoerror_value_HW_second            = 1,
-    eoerror_value_HW_strain_saturation = 2
+    eoerror_value_HW_first                   = 0,
+    eoerror_value_HW_second                  = 1,
+    eoerror_value_HW_strain_saturation       = 2,
+    eoerror_value_HW_encoder_invalid_value   = 3,
+    eoerror_value_HW_encoder_close_to_limits = 4,
+    eoerror_value_HW_encoder_crc             = 5,
+    eoerror_value_HW_encoder_not_connected   = 6
 } eOerror_value_HW_t;
 
-enum { eoerror_value_HW_numberof = 3 };
+enum { eoerror_value_HW_numberof = 7 };
 
 
 


### PR DESCRIPTION
**What's new:**

- the `eoerror_valuestrings_HW` list has been extended including possible error messages coming from the new `AksIM2` encoder.
- the `eOerror_value_HW_t` reflects the same changes

**Notes:**
- These changes are required to be able to parse the error messages sent from the new FW.
- Tested on `5-improved-joint` setup (composed by EMS + AksIM2 + BLDC Motor)

cc @ale-git @pattacini 