### PR TITLE
HandMK5: fix names of joints and connectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.32.0)
+        VERSION 1.32.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -56,18 +56,18 @@ extern "C" {
 
 // - declaration of public user-defined types -------------------------------------------------------------------------
 
-// use eoas_sensor2string() and eoas_string2sensor() to convert to / from eOas_sensor_t and associated string 
+// use eoas_sensor2string() and eoas_string2sensor() to convert to / from eOas_sensor_t and associated string
 typedef enum
 {
     eoas_strain                 = 0,    // associated string is: "eoas_strain"
     eoas_mais                   = 1,    // etc ... the string is equal to the enum
-    eoas_accel_mtb_int          = 2,   
-    eoas_accel_mtb_ext          = 3,    
-    eoas_gyros_mtb_ext          = 4,    
-    eoas_accel_st_lis3x         = 5,    
-    eoas_gyros_st_l3g4200d      = 6, 
-    eoas_imu_acc                = 7,   
-    eoas_imu_mag                = 8,  
+    eoas_accel_mtb_int          = 2,
+    eoas_accel_mtb_ext          = 3,
+    eoas_gyros_mtb_ext          = 4,
+    eoas_accel_st_lis3x         = 5,
+    eoas_gyros_st_l3g4200d      = 6,
+    eoas_imu_acc                = 7,
+    eoas_imu_mag                = 8,
     eoas_imu_gyr                = 9,
     eoas_imu_eul                = 10,
     eoas_imu_qua                = 11,
@@ -80,8 +80,8 @@ typedef enum
     eoas_ft                     = 18,
     eoas_battery             = 19,
     // add in here eoas_xxxnameetc
-    eoas_unknown                = 254,  
-    eoas_none                   = 255   
+    eoas_unknown                = 254,
+    eoas_none                   = 255
 } eOas_sensor_t;
 
 enum { eoas_sensors_numberof = 20 };
@@ -95,7 +95,7 @@ typedef enum
 {
     eoas_entity_strain                      = 0,
     eoas_entity_mais                        = 1,
-    eoas_entity_temperature                 = 2,    
+    eoas_entity_temperature                 = 2,
     eoas_entity_inertial                    = 3,
     eoas_entity_inertial3                   = 4,
     eoas_entity_psc                         = 5,
@@ -308,7 +308,7 @@ typedef struct
 // we use this struct to send activate-verify command to the board
 enum { eOas_temperature_descriptors_maxnumber = 7 };
 typedef struct
-{   
+{
     eOarray_head_t                      head;
     eOas_temperature_descriptor_t       data[eOas_temperature_descriptors_maxnumber];
 } eOas_temperature_arrayof_descriptors_t; EO_VERIFYsizeof(eOas_temperature_arrayof_descriptors_t, 32)
@@ -328,14 +328,14 @@ typedef struct
     uint8_t     id;             // an id which is shared by transmitter and receiver. it can be a unique number or an index inside the array-of-sensors
     uint8_t     typeofsensor;   // use eOas_temperature_type_t
     int16_t     value;          // each unit is 0.1 Celsius (maybe move to 0.01 kelvin ...)
-    uint32_t    timestamp;      // the time in msec of reception of this data. it is circular in about an hour 
+    uint32_t    timestamp;      // the time in msec of reception of this data. it is circular in about an hour
 } eOas_temperature_data_t;      EO_VERIFYsizeof(eOas_temperature_data_t, 8)
 
 
 // nota di marco.accame: enabled kept at 16 bits so that we can have eOas_temperature_descriptors_maxnumber up to 15.
 typedef struct
 {
-    uint16_t                    datarate;       // it specifies the acquisition rate in seconds with accepted range. 
+    uint16_t                    datarate;       // it specifies the acquisition rate in seconds with accepted range.
     uint16_t                    enabled;        // bitmask of enabled sensors with reference to array-of-sensors
 } eOas_temperature_config_t;    EO_VERIFYsizeof(eOas_temperature_config_t, 4)
 
@@ -454,7 +454,7 @@ typedef enum
     eoas_inertial3_accel_ems_st_lis3x       = eoas_accel_st_lis3x,
     eoas_inertial3_gyros_ems_st_l3g4200d    = eoas_gyros_st_l3g4200d,
     // new imu-based sensors
-    eoas_inertial3_imu_acc                  = eoas_imu_acc,     
+    eoas_inertial3_imu_acc                  = eoas_imu_acc,
     eoas_inertial3_imu_mag                  = eoas_imu_mag,
     eoas_inertial3_imu_gyr                  = eoas_imu_gyr,
     eoas_inertial3_imu_eul                  = eoas_imu_eul,
@@ -462,7 +462,7 @@ typedef enum
     eoas_inertial3_imu_lia                  = eoas_imu_lia,
     eoas_inertial3_imu_grv                  = eoas_imu_grv,
     eoas_inertial3_imu_status               = eoas_imu_status,
-    
+
     eoas_inertial3_unknown                  = eoas_unknown,
     eoas_inertial3_none                     = eoas_none
 } eOas_inertial3_type_t;
@@ -571,7 +571,7 @@ typedef struct
     eObrd_canlocation_t                 canloc[eOas_psc_boards_maxnumber];
 } eOas_psc_canLocationsInfo_t;
 
-// a single psc sensor contains an angle expressed in deci-degrees 
+// a single psc sensor contains an angle expressed in deci-degrees
 // this struct describes the data acquired by a single psc sensor
 typedef struct
 {
@@ -623,7 +623,7 @@ typedef enum
 {
     eoas_pos_TYPE_decideg = 0,
     eoas_pos_TYPE_none = 14,
-    eoas_pos_TYPE_unknown = 15    
+    eoas_pos_TYPE_unknown = 15
 } eoas_pos_TYPE_t;
 enum { eoas_pos_TYPE_numberof = 1 };
 
@@ -641,14 +641,14 @@ enum { eoas_pos_ROT_numberof = 4 };
 // each sensor on the board is identified by:
 // - a type which specifies the nature of the quantity read by the sensor. so far we only have eoas_pos_TYPE_decideg, so rotational angle expressed in 0.1 deg
 // - a connector to which the sensor is attached in the board or the embot::hw::ID of the relevant device
-// - a port to which its reading is associated in the CAN protocol (via its label filed) so that we can understand if it is a POS:hand_thumb or POS:hand_index
+// - a port to which its reading is associated in the CAN protocol (via its label filed) so that we can understand if it is a POS:hand_thumb_oc or POS:hand_index_oc
 // - a boolean telling if the sensor is enabled or not
 // - some calibration parameters which are used to map the decideg reading in a valid range without zero crossing
 typedef struct
 {
-    uint16_t type               : 4; // use eoas_pos_TYPE_t 
+    uint16_t type               : 4; // use eoas_pos_TYPE_t
     uint16_t connector          : 4; // connector on the board (0, 1, 2, ...) or id of the embot::hw device
-    uint16_t port               : 4; // [0, 1, ..., 15], BUT: use values such as POS:hand_thumb taken from eObrd_portpos_t
+    uint16_t port               : 4; // [0, 1, ..., 15], BUT: use values such as POS:hand_thumb_oc taken from eObrd_portpos_t
     uint16_t enabled            : 1; // if 1 is enabled
     uint16_t invertdirection    : 1;
     uint16_t rotation           : 2; // use eoas_pos_ROT_t except for eoas_pos_ROT_unknown
@@ -661,7 +661,7 @@ typedef struct
     eObrd_info_t            boardinfo;
     eObrd_canlocation_t     canloc;
     uint8_t                 filler[1];
-    eoas_pos_SensorConfig_t sensors[eOas_pos_sensorsinboard_maxnumber];   
+    eoas_pos_SensorConfig_t sensors[eOas_pos_sensorsinboard_maxnumber];
 } eoas_pos_BoardConfig_t; EO_VERIFYsizeof(eoas_pos_BoardConfig_t, 24)
 
 typedef struct
@@ -669,7 +669,7 @@ typedef struct
     eoas_pos_BoardConfig_t boardconfig[eOas_pos_boards_maxnumber];
 } eoas_pos_ServiceConfig_t; EO_VERIFYsizeof(eoas_pos_ServiceConfig_t, 24)
 
-// a single pos sensor contains an angle expressed in deci-degrees 
+// a single pos sensor contains an angle expressed in deci-degrees
 // this struct describes the data acquired by a single pos sensor
 typedef struct
 {
@@ -741,7 +741,7 @@ typedef struct
 
 typedef struct
 {
-    eOarray_head_t              head;//4                                                                                                  
+    eOarray_head_t              head;//4
     eOas_battery_sensordescriptor_t  data[eOas_battery_sensors_maxnumber];
 } eOas_battery_arrayof_sensors_t;  EO_VERIFYsizeof(eOas_battery_arrayof_sensors_t, 12)
 
@@ -752,10 +752,10 @@ enum { eoas_ft_6axis = 6 };
 
 typedef struct
 {
-    eOenum08_t              mode;               // use eOas_ft_mode_t                                 
-    uint8_t                 ftperiod;           // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
+    eOenum08_t              mode;               // use eOas_ft_mode_t
+    uint8_t                 ftperiod;           // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms}
     uint8_t                 calibrationset;     // can be calibration set 0, 1, 2
-    uint8_t                 temperatureperiod;  // in seconds 
+    uint8_t                 temperatureperiod;  // in seconds
 } eOas_ft_config_t;         EO_VERIFYsizeof(eOas_ft_config_t, 4)
 
 
@@ -772,16 +772,16 @@ typedef struct
     uint32_t                info;         // ffu ... used-calib-set, saturated info, calib/notcalib, candata-not-heard-of-since-ms-ago, ... boh it is worth using extra 8 bytes?
     uint16_t                ffu;
     eOmeas_temperature_t    temperature;  // in steps of 0.1 celsius degree (pos and neg).
-    float32_t               values[eoas_ft_6axis];    // they may be [f, t] or also the 6 adc values or also ... see info.    
+    float32_t               values[eoas_ft_6axis];    // they may be [f, t] or also the 6 adc values or also ... see info.
 } eOas_ft_timedvalue_t;     EO_VERIFYsizeof(eOas_ft_timedvalue_t, 40)
 
 
-typedef struct    
+typedef struct
 {   // 40 + 12 + 4 = 56
     eOas_ft_timedvalue_t    timedvalue;
     uint16_t                fullscale[eoas_ft_6axis];
-    uint8_t                 mode;       // calibrated, not calibrated, may it be useful ????  
-    uint8_t                 filler[3];    
+    uint8_t                 mode;       // calibrated, not calibrated, may it be useful ????
+    uint8_t                 filler[3];
 } eOas_ft_status_t;         EO_VERIFYsizeof(eOas_ft_status_t, 56)
 
 
@@ -815,14 +815,14 @@ typedef struct
     int16_t                 temperature;  // in steps of 0.1 celsius degree (pos and neg).
     int8_t                  status;
     uint8_t                 filler;
-    float32_t               voltage;  
-    float32_t               current;  
-    float32_t               charge;  
+    float32_t               voltage;
+    float32_t               current;
+    float32_t               charge;
 
 } eOas_battery_timedvalue_t;     EO_VERIFYsizeof(eOas_battery_timedvalue_t, 24)
 //char (*luca)[sizeof( eOas_battery_timedvalue_t )] = 1;
 
-typedef struct    
+typedef struct
 {   // 40 + 12 + 4 = 56
     eOas_battery_timedvalue_t    timedvalue;
 } eOas_battery_status_t;         EO_VERIFYsizeof(eOas_battery_status_t, 24)
@@ -847,7 +847,7 @@ extern const char * eoas_sensor2string(eOas_sensor_t sensor);
 extern eOas_sensor_t eoas_string2sensor(const char * string);
 
 extern eOresult_t eoas_inertial3_setof_boardinfos_clear(eOas_inertial3_setof_boardinfos_t *set);
-extern eOresult_t eoas_inertial3_setof_boardinfos_add(eOas_inertial3_setof_boardinfos_t *set, const eObrd_info_t *brdinfo); 
+extern eOresult_t eoas_inertial3_setof_boardinfos_add(eOas_inertial3_setof_boardinfos_t *set, const eObrd_info_t *brdinfo);
 extern const eObrd_info_t * eoas_inertial3_setof_boardinfos_find(const eOas_inertial3_setof_boardinfos_t *set, eObrd_cantype_t brdtype);
 
 extern uint8_t eoas_inertial3_supportedboards_numberof(void);
@@ -857,7 +857,7 @@ extern icubCanProto_imu_sensor_t eoas_inertial3_imu_to_canproto(eOas_inertial3_t
 extern eOas_inertial3_type_t eoas_inertial3_canproto_to_imu(uint8_t v);
 
 extern eOresult_t eoas_temperature_setof_boardinfos_clear(eOas_temperature_setof_boardinfos_t *set);
-extern eOresult_t eoas_temperature_setof_boardinfos_add(eOas_temperature_setof_boardinfos_t *set, const eObrd_info_t *brdinfo); 
+extern eOresult_t eoas_temperature_setof_boardinfos_add(eOas_temperature_setof_boardinfos_t *set, const eObrd_info_t *brdinfo);
 extern const eObrd_info_t * eoas_temperature_setof_boardinfos_find(const eOas_temperature_setof_boardinfos_t *set, eObrd_cantype_t brdtype);
 
 extern uint8_t eoas_temperature_supportedboards_numberof(void);

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -56,18 +56,18 @@ extern "C" {
 
 // - declaration of public user-defined types -------------------------------------------------------------------------
 
-// use eoas_sensor2string() and eoas_string2sensor() to convert to / from eOas_sensor_t and associated string
+// use eoas_sensor2string() and eoas_string2sensor() to convert to / from eOas_sensor_t and associated string 
 typedef enum
 {
     eoas_strain                 = 0,    // associated string is: "eoas_strain"
     eoas_mais                   = 1,    // etc ... the string is equal to the enum
-    eoas_accel_mtb_int          = 2,
-    eoas_accel_mtb_ext          = 3,
-    eoas_gyros_mtb_ext          = 4,
-    eoas_accel_st_lis3x         = 5,
-    eoas_gyros_st_l3g4200d      = 6,
-    eoas_imu_acc                = 7,
-    eoas_imu_mag                = 8,
+    eoas_accel_mtb_int          = 2,   
+    eoas_accel_mtb_ext          = 3,    
+    eoas_gyros_mtb_ext          = 4,    
+    eoas_accel_st_lis3x         = 5,    
+    eoas_gyros_st_l3g4200d      = 6, 
+    eoas_imu_acc                = 7,   
+    eoas_imu_mag                = 8,  
     eoas_imu_gyr                = 9,
     eoas_imu_eul                = 10,
     eoas_imu_qua                = 11,
@@ -80,8 +80,8 @@ typedef enum
     eoas_ft                     = 18,
     eoas_battery             = 19,
     // add in here eoas_xxxnameetc
-    eoas_unknown                = 254,
-    eoas_none                   = 255
+    eoas_unknown                = 254,  
+    eoas_none                   = 255   
 } eOas_sensor_t;
 
 enum { eoas_sensors_numberof = 20 };
@@ -95,7 +95,7 @@ typedef enum
 {
     eoas_entity_strain                      = 0,
     eoas_entity_mais                        = 1,
-    eoas_entity_temperature                 = 2,
+    eoas_entity_temperature                 = 2,    
     eoas_entity_inertial                    = 3,
     eoas_entity_inertial3                   = 4,
     eoas_entity_psc                         = 5,
@@ -308,7 +308,7 @@ typedef struct
 // we use this struct to send activate-verify command to the board
 enum { eOas_temperature_descriptors_maxnumber = 7 };
 typedef struct
-{
+{   
     eOarray_head_t                      head;
     eOas_temperature_descriptor_t       data[eOas_temperature_descriptors_maxnumber];
 } eOas_temperature_arrayof_descriptors_t; EO_VERIFYsizeof(eOas_temperature_arrayof_descriptors_t, 32)
@@ -328,14 +328,14 @@ typedef struct
     uint8_t     id;             // an id which is shared by transmitter and receiver. it can be a unique number or an index inside the array-of-sensors
     uint8_t     typeofsensor;   // use eOas_temperature_type_t
     int16_t     value;          // each unit is 0.1 Celsius (maybe move to 0.01 kelvin ...)
-    uint32_t    timestamp;      // the time in msec of reception of this data. it is circular in about an hour
+    uint32_t    timestamp;      // the time in msec of reception of this data. it is circular in about an hour 
 } eOas_temperature_data_t;      EO_VERIFYsizeof(eOas_temperature_data_t, 8)
 
 
 // nota di marco.accame: enabled kept at 16 bits so that we can have eOas_temperature_descriptors_maxnumber up to 15.
 typedef struct
 {
-    uint16_t                    datarate;       // it specifies the acquisition rate in seconds with accepted range.
+    uint16_t                    datarate;       // it specifies the acquisition rate in seconds with accepted range. 
     uint16_t                    enabled;        // bitmask of enabled sensors with reference to array-of-sensors
 } eOas_temperature_config_t;    EO_VERIFYsizeof(eOas_temperature_config_t, 4)
 
@@ -454,7 +454,7 @@ typedef enum
     eoas_inertial3_accel_ems_st_lis3x       = eoas_accel_st_lis3x,
     eoas_inertial3_gyros_ems_st_l3g4200d    = eoas_gyros_st_l3g4200d,
     // new imu-based sensors
-    eoas_inertial3_imu_acc                  = eoas_imu_acc,
+    eoas_inertial3_imu_acc                  = eoas_imu_acc,     
     eoas_inertial3_imu_mag                  = eoas_imu_mag,
     eoas_inertial3_imu_gyr                  = eoas_imu_gyr,
     eoas_inertial3_imu_eul                  = eoas_imu_eul,
@@ -462,7 +462,7 @@ typedef enum
     eoas_inertial3_imu_lia                  = eoas_imu_lia,
     eoas_inertial3_imu_grv                  = eoas_imu_grv,
     eoas_inertial3_imu_status               = eoas_imu_status,
-
+    
     eoas_inertial3_unknown                  = eoas_unknown,
     eoas_inertial3_none                     = eoas_none
 } eOas_inertial3_type_t;
@@ -571,7 +571,7 @@ typedef struct
     eObrd_canlocation_t                 canloc[eOas_psc_boards_maxnumber];
 } eOas_psc_canLocationsInfo_t;
 
-// a single psc sensor contains an angle expressed in deci-degrees
+// a single psc sensor contains an angle expressed in deci-degrees 
 // this struct describes the data acquired by a single psc sensor
 typedef struct
 {
@@ -623,7 +623,7 @@ typedef enum
 {
     eoas_pos_TYPE_decideg = 0,
     eoas_pos_TYPE_none = 14,
-    eoas_pos_TYPE_unknown = 15
+    eoas_pos_TYPE_unknown = 15    
 } eoas_pos_TYPE_t;
 enum { eoas_pos_TYPE_numberof = 1 };
 
@@ -641,14 +641,14 @@ enum { eoas_pos_ROT_numberof = 4 };
 // each sensor on the board is identified by:
 // - a type which specifies the nature of the quantity read by the sensor. so far we only have eoas_pos_TYPE_decideg, so rotational angle expressed in 0.1 deg
 // - a connector to which the sensor is attached in the board or the embot::hw::ID of the relevant device
-// - a port to which its reading is associated in the CAN protocol (via its label filed) so that we can understand if it is a POS:hand_thumb_oc or POS:hand_index_oc
+// - a port to which its reading is associated in the CAN protocol (via its label filed) so that we can understand if it is a POS:hand_thumb or POS:hand_index
 // - a boolean telling if the sensor is enabled or not
 // - some calibration parameters which are used to map the decideg reading in a valid range without zero crossing
 typedef struct
 {
-    uint16_t type               : 4; // use eoas_pos_TYPE_t
+    uint16_t type               : 4; // use eoas_pos_TYPE_t 
     uint16_t connector          : 4; // connector on the board (0, 1, 2, ...) or id of the embot::hw device
-    uint16_t port               : 4; // [0, 1, ..., 15], BUT: use values such as POS:hand_thumb_oc taken from eObrd_portpos_t
+    uint16_t port               : 4; // [0, 1, ..., 15], BUT: use values taken from eObrd_portpos_t
     uint16_t enabled            : 1; // if 1 is enabled
     uint16_t invertdirection    : 1;
     uint16_t rotation           : 2; // use eoas_pos_ROT_t except for eoas_pos_ROT_unknown
@@ -661,7 +661,7 @@ typedef struct
     eObrd_info_t            boardinfo;
     eObrd_canlocation_t     canloc;
     uint8_t                 filler[1];
-    eoas_pos_SensorConfig_t sensors[eOas_pos_sensorsinboard_maxnumber];
+    eoas_pos_SensorConfig_t sensors[eOas_pos_sensorsinboard_maxnumber];   
 } eoas_pos_BoardConfig_t; EO_VERIFYsizeof(eoas_pos_BoardConfig_t, 24)
 
 typedef struct
@@ -669,7 +669,7 @@ typedef struct
     eoas_pos_BoardConfig_t boardconfig[eOas_pos_boards_maxnumber];
 } eoas_pos_ServiceConfig_t; EO_VERIFYsizeof(eoas_pos_ServiceConfig_t, 24)
 
-// a single pos sensor contains an angle expressed in deci-degrees
+// a single pos sensor contains an angle expressed in deci-degrees 
 // this struct describes the data acquired by a single pos sensor
 typedef struct
 {
@@ -741,7 +741,7 @@ typedef struct
 
 typedef struct
 {
-    eOarray_head_t              head;//4
+    eOarray_head_t              head;//4                                                                                                  
     eOas_battery_sensordescriptor_t  data[eOas_battery_sensors_maxnumber];
 } eOas_battery_arrayof_sensors_t;  EO_VERIFYsizeof(eOas_battery_arrayof_sensors_t, 12)
 
@@ -752,10 +752,10 @@ enum { eoas_ft_6axis = 6 };
 
 typedef struct
 {
-    eOenum08_t              mode;               // use eOas_ft_mode_t
-    uint8_t                 ftperiod;           // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms}
+    eOenum08_t              mode;               // use eOas_ft_mode_t                                 
+    uint8_t                 ftperiod;           // if 0 -> DONT TX, else if(strain2) { in ms from 1 to 254, 255 = 500 us} else if(strain) { in ms from 1 up to 210 ms} 
     uint8_t                 calibrationset;     // can be calibration set 0, 1, 2
-    uint8_t                 temperatureperiod;  // in seconds
+    uint8_t                 temperatureperiod;  // in seconds 
 } eOas_ft_config_t;         EO_VERIFYsizeof(eOas_ft_config_t, 4)
 
 
@@ -772,16 +772,16 @@ typedef struct
     uint32_t                info;         // ffu ... used-calib-set, saturated info, calib/notcalib, candata-not-heard-of-since-ms-ago, ... boh it is worth using extra 8 bytes?
     uint16_t                ffu;
     eOmeas_temperature_t    temperature;  // in steps of 0.1 celsius degree (pos and neg).
-    float32_t               values[eoas_ft_6axis];    // they may be [f, t] or also the 6 adc values or also ... see info.
+    float32_t               values[eoas_ft_6axis];    // they may be [f, t] or also the 6 adc values or also ... see info.    
 } eOas_ft_timedvalue_t;     EO_VERIFYsizeof(eOas_ft_timedvalue_t, 40)
 
 
-typedef struct
+typedef struct    
 {   // 40 + 12 + 4 = 56
     eOas_ft_timedvalue_t    timedvalue;
     uint16_t                fullscale[eoas_ft_6axis];
-    uint8_t                 mode;       // calibrated, not calibrated, may it be useful ????
-    uint8_t                 filler[3];
+    uint8_t                 mode;       // calibrated, not calibrated, may it be useful ????  
+    uint8_t                 filler[3];    
 } eOas_ft_status_t;         EO_VERIFYsizeof(eOas_ft_status_t, 56)
 
 
@@ -815,14 +815,14 @@ typedef struct
     int16_t                 temperature;  // in steps of 0.1 celsius degree (pos and neg).
     int8_t                  status;
     uint8_t                 filler;
-    float32_t               voltage;
-    float32_t               current;
-    float32_t               charge;
+    float32_t               voltage;  
+    float32_t               current;  
+    float32_t               charge;  
 
 } eOas_battery_timedvalue_t;     EO_VERIFYsizeof(eOas_battery_timedvalue_t, 24)
 //char (*luca)[sizeof( eOas_battery_timedvalue_t )] = 1;
 
-typedef struct
+typedef struct    
 {   // 40 + 12 + 4 = 56
     eOas_battery_timedvalue_t    timedvalue;
 } eOas_battery_status_t;         EO_VERIFYsizeof(eOas_battery_status_t, 24)
@@ -847,7 +847,7 @@ extern const char * eoas_sensor2string(eOas_sensor_t sensor);
 extern eOas_sensor_t eoas_string2sensor(const char * string);
 
 extern eOresult_t eoas_inertial3_setof_boardinfos_clear(eOas_inertial3_setof_boardinfos_t *set);
-extern eOresult_t eoas_inertial3_setof_boardinfos_add(eOas_inertial3_setof_boardinfos_t *set, const eObrd_info_t *brdinfo);
+extern eOresult_t eoas_inertial3_setof_boardinfos_add(eOas_inertial3_setof_boardinfos_t *set, const eObrd_info_t *brdinfo); 
 extern const eObrd_info_t * eoas_inertial3_setof_boardinfos_find(const eOas_inertial3_setof_boardinfos_t *set, eObrd_cantype_t brdtype);
 
 extern uint8_t eoas_inertial3_supportedboards_numberof(void);
@@ -857,7 +857,7 @@ extern icubCanProto_imu_sensor_t eoas_inertial3_imu_to_canproto(eOas_inertial3_t
 extern eOas_inertial3_type_t eoas_inertial3_canproto_to_imu(uint8_t v);
 
 extern eOresult_t eoas_temperature_setof_boardinfos_clear(eOas_temperature_setof_boardinfos_t *set);
-extern eOresult_t eoas_temperature_setof_boardinfos_add(eOas_temperature_setof_boardinfos_t *set, const eObrd_info_t *brdinfo);
+extern eOresult_t eoas_temperature_setof_boardinfos_add(eOas_temperature_setof_boardinfos_t *set, const eObrd_info_t *brdinfo); 
 extern const eObrd_info_t * eoas_temperature_setof_boardinfos_find(const eOas_temperature_setof_boardinfos_t *set, eObrd_cantype_t brdtype);
 
 extern uint8_t eoas_temperature_supportedboards_numberof(void);

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -291,7 +291,7 @@ static const eOmap_str_str_u08_t s_boards_map_of_portposs[] =
     {"hand_index_oc", "eobrd_portpos_hand_index_oc", eobrd_portpos_hand_index_oc},
     {"hand_middle_oc", "eobrd_portpos_hand_middle_oc", eobrd_portpos_hand_middle_oc},
     {"hand_ring_pinky_oc", "eobrd_portpos_hand_ring_pinky_oc", eobrd_portpos_hand_ring_pinky_oc},
-    {"hand_hand_thumb_add", "eobrd_portpos_hand_thumb_add", eobrd_portpos_hand_thumb_add},
+    {"hand_thumb_add", "eobrd_portpos_hand_thumb_add", eobrd_portpos_hand_thumb_add},
     {"hand_tbd", "eobrd_portpos_hand_tbd", eobrd_portpos_hand_tbd},
     {"hand_index_add", "eobrd_portpos_hand_index_add", eobrd_portpos_hand_index_add},
     

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -27,7 +27,7 @@
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
 
-#include "stdlib.h" 
+#include "stdlib.h"
 #include "string.h"
 #include "stdio.h"
 
@@ -41,7 +41,7 @@
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - declaration of extern hidden interface 
+// - declaration of extern hidden interface
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 
@@ -68,14 +68,14 @@
 // - definition (and initialisation) of static variables
 // --------------------------------------------------------------------------------------------------------------------
 
-static const uint64_t s_eoboards_is_eth_mask =  (0x1LL << eobrd_ems4) | 
-                                                (0x1LL << eobrd_mc4plus) | 
+static const uint64_t s_eoboards_is_eth_mask =  (0x1LL << eobrd_ems4) |
+                                                (0x1LL << eobrd_mc4plus) |
                                                 (0x1LL << eobrd_mc2plus) |
                                                 (0x1LL << eobrd_amc);
 
-static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) | 
-                                                (0x1LL << eobrd_mtb) | 
-                                                (0x1LL << eobrd_strain) |                                                
+static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
+                                                (0x1LL << eobrd_mtb) |
+                                                (0x1LL << eobrd_strain) |
                                                 (0x1LL << eobrd_mais) |
                                                 (0x1LL << eobrd_foc) |
                                                 (0x1LL << eobrd_dsp) |
@@ -96,25 +96,25 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_mtb4c) |
                                                 (0x1LL << eobrd_mtb4fap) |
                                                 (0x1LL << eobrd_strain2c);
-       
-   
+
+
 static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
-{    
+{
     {"ems4", "eobrd_ems4", eobrd_ems4},
     {"mc4plus", "eobrd_mc4plus", eobrd_mc4plus},
     {"mc2plus", "eobrd_mc2plus", eobrd_mc2plus},
     {"amc", "eobrd_amc", eobrd_amc},
-    
+
     {"mc4", "eobrd_mc4", eobrd_mc4},
     {"mtb", "eobrd_mtb", eobrd_mtb},
     {"strain", "eobrd_strain", eobrd_strain},
     {"mais", "eobrd_mais", eobrd_mais},
     {"foc", "eobrd_foc", eobrd_foc},
-    
+
     {"dsp", "eobrd_dsp", eobrd_dsp},
     {"pic", "eobrd_pic", eobrd_pic},
     {"2dc", "eobrd_2dc", eobrd_2dc},
-    {"bll", "eobrd_bll", eobrd_bll},    
+    {"bll", "eobrd_bll", eobrd_bll},
     {"6sg", "eobrd_6sg", eobrd_6sg},
     {"jog", "eobrd_jog", eobrd_jog},
     {"mtb4", "eobrd_mtb4", eobrd_mtb4},
@@ -129,7 +129,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"mtb4c", "eobrd_mtb4c", eobrd_mtb4c},
     {"mtb4fap", "eobrd_mtb4fap", eobrd_mtb4fap},
     {"strain2c", "eobrd_strain2c", eobrd_strain2c},
-    
+
     {"none", "eobrd_none", eobrd_none},
     {"unknown", "eobrd_unknown", eobrd_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_boards, (eobrd_type_numberof+2)*sizeof(eOmap_str_str_u08_t))
@@ -137,7 +137,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
 
 
 static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
-{    
+{
     {"P1", "eobrd_conn_P1",eobrd_conn_P1},
     {"P2", "eobrd_conn_P2", eobrd_conn_P2},
     {"P3", "eobrd_conn_P3", eobrd_conn_P3},
@@ -164,28 +164,28 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"J5", "eobrd_conn_J5", eobrd_conn_J5},
     {"J6", "eobrd_conn_J6", eobrd_conn_J6},
     {"J7", "eobrd_conn_J7", eobrd_conn_J7},
-    
+
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_connectors, (eobrd_connectors_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
 static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
-{//  shortname  longname          port value        boardtype   connector  
+{//  shortname  longname          port value        boardtype   connector
     {"emsP6", "eobrd_port_emsP6", eobrd_port_emsP6, eobrd_ems4, eobrd_conn_P6},
     {"emsP7", "eobrd_port_emsP7", eobrd_port_emsP7, eobrd_ems4, eobrd_conn_P7},
     {"emsP8", "eobrd_port_emsP8", eobrd_port_emsP8, eobrd_ems4, eobrd_conn_P8},
     {"emsP9", "eobrd_port_emsP9", eobrd_port_emsP9, eobrd_ems4, eobrd_conn_P9},
     {"emsP10", "eobrd_port_emsP10", eobrd_port_emsP10, eobrd_ems4, eobrd_conn_P10},
     {"emsP11", "eobrd_port_emsP11", eobrd_port_emsP11, eobrd_ems4, eobrd_conn_P11},
-    
+
     {"mc4plusP2", "eobrd_port_mc4plusP2", eobrd_port_mc4plusP2, eobrd_mc4plus, eobrd_conn_P2},
     {"mc4plusP3", "eobrd_port_mc4plusP3", eobrd_port_mc4plusP3, eobrd_mc4plus, eobrd_conn_P3},
     {"mc4plusP4", "eobrd_port_mc4plusP4", eobrd_port_mc4plusP4, eobrd_mc4plus, eobrd_conn_P4},
     {"mc4plusP5", "eobrd_port_mc4plusP5", eobrd_port_mc4plusP5, eobrd_mc4plus, eobrd_conn_P5},
     {"mc4plusP10", "eobrd_port_mc4plusP10", eobrd_port_mc4plusP10, eobrd_mc4plus, eobrd_conn_P10},
     {"mc4plusP11", "eobrd_port_mc4plusP11", eobrd_port_mc4plusP11, eobrd_mc4plus, eobrd_conn_P11},
-    
+
     {"mc2plusP2", "eobrd_port_mc2plusP2", eobrd_port_mc2plusP2, eobrd_mc2plus, eobrd_conn_P2},
     {"mc2plusP3", "eobrd_port_mc2plusP3", eobrd_port_mc2plusP3, eobrd_mc2plus, eobrd_conn_P3},
     {"mc2plusP10", "eobrd_port_mc2plusP10", eobrd_port_mc2plusP10, eobrd_mc2plus, eobrd_conn_P10},
@@ -194,7 +194,7 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"amcJ5_X1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
     {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
     {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
-    
+
     {"mtb4fap_J3_SDA0", "eobrd_port_mtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
     {"mtb4fap_J3_SDA1", "eobrd_port_mtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
     {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
@@ -214,7 +214,7 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"pmc_J5", "eobrd_port_pmc_J5", eobrd_port_pmc_J5, eobrd_pmc, eobrd_conn_J5},
     {"pmc_J6", "eobrd_port_pmc_J6", eobrd_port_pmc_J6, eobrd_pmc, eobrd_conn_J6},
     {"pmc_J7", "eobrd_port_pmc_J7", eobrd_port_pmc_J7, eobrd_pmc, eobrd_conn_J7},
-    
+
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_ports, (eobrd_ports_numberof+2)*sizeof(eOmap_str_str_u08_u08_u08_t))
@@ -229,9 +229,9 @@ static const eOmap_str_str_u08_t s_boards_map_of_portmaiss[] =
     {"mediumproximal", "eobrd_portmais_mediumproximal", eobrd_portmais_mediumproximal},
     {"mediumdistal", "eobrd_portmais_mediumdistal", eobrd_portmais_mediumdistal},
     {"littlefingers", "eobrd_portmais_littlefingers", eobrd_portmais_littlefingers},
-    
+
     {"none", "eobrd_portmais_none", eobrd_portmais_none},
-    {"unknown", "eobrd_portmais_unknown", eobrd_portmais_unknown}    
+    {"unknown", "eobrd_portmais_unknown", eobrd_portmais_unknown}
 };  EO_VERIFYsizeof(s_boards_map_of_portmaiss, (eobrd_portmaiss_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -239,24 +239,24 @@ static const eOmap_str_str_u08_t s_boards_map_of_portpscs[] =
 {
     {"finger0", "eobrd_portpsc_finger0", eobrd_portpsc_finger0},
     {"finger1", "eobrd_portpsc_finger1", eobrd_portpsc_finger1},
-    
+
     {"none", "eobrd_portpsc_none", eobrd_portpsc_none},
-    {"unknown", "eobrd_portpsc_unknown", eobrd_portpsc_unknown}    
+    {"unknown", "eobrd_portpsc_unknown", eobrd_portpsc_unknown}
 };  EO_VERIFYsizeof(s_boards_map_of_portpscs, (eobrd_portpscs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
 static const eOmap_str_str_u08_t s_boards_map_of_portposs[] =
 {
-    {"hand_thumb", "eobrd_portpos_hand_thumb", eobrd_portpos_hand_thumb},
-    {"hand_index", "eobrd_portpos_hand_index", eobrd_portpos_hand_index},
-    {"hand_medium", "eobrd_portpos_hand_medium", eobrd_portpos_hand_medium},
-    {"hand_pinky", "eobrd_portpos_hand_pinky", eobrd_portpos_hand_pinky},
-    {"hand_thumbmetacarpus", "eobrd_portpos_hand_thumbmetacarpus", eobrd_portpos_hand_thumbmetacarpus},
+    {"hand_thumb_oc", "eobrd_portpos_hand_thumb_oc", eobrd_portpos_hand_thumb_oc},
+    {"hand_index_oc", "eobrd_portpos_hand_index_oc", eobrd_portpos_hand_index_oc},
+    {"hand_middle_oc", "eobrd_portpos_hand_middle_oc", eobrd_portpos_hand_middle_oc},
+    {"hand_ring_pinky_oc", "eobrd_portpos_hand_ring_pinky_oc", eobrd_portpos_hand_ring_pinky_oc},
+    {"hand_thumb_add", "eobrd_portpos_hand_thumb_add", eobrd_portpos_hand_thumb_add},
     {"hand_thumbrotation", "eobrd_portpos_hand_thumbrotation", eobrd_portpos_hand_thumbrotation},
-    {"hand_indexadduction", "eobrd_portpos_hand_indexadduction", eobrd_portpos_hand_indexadduction},
-    
+    {"hand_index_add", "eobrd_portpos_hand_index_add", eobrd_portpos_hand_index_add},
+
     {"none", "eobrd_portpos_none", eobrd_portpos_none},
-    {"unknown", "eobrd_portpos_unknown", eobrd_portpos_unknown}    
+    {"unknown", "eobrd_portpos_unknown", eobrd_portpos_unknown}
 };  EO_VERIFYsizeof(s_boards_map_of_portposs, (eobrd_portposs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -268,7 +268,7 @@ static const eOmap_str_str_u08_t s_boards_map_of_reportmodes[] =
     {"ALL", "eobrd_canmonitor_reportmode_ALL", eobrd_canmonitor_reportmode_ALL},
 
     {"none", "eobrd_canmonitor_reportmode_none", eobrd_canmonitor_reportmode_none},
-    {"unknown", "eobrd_canmonitor_reportmode_unknown", eobrd_canmonitor_reportmode_unknown}    
+    {"unknown", "eobrd_canmonitor_reportmode_unknown", eobrd_canmonitor_reportmode_unknown}
 };  EO_VERIFYsizeof(s_boards_map_of_reportmodes, (eobrd_reportmodes_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -289,8 +289,8 @@ extern eObool_t eoboards_is_can(eObrd_type_t type)
     {
         return(eobool_false);
     }
- 
-    return(eo_common_dword_bitcheck(s_eoboards_is_can_mask, type));      
+
+    return(eo_common_dword_bitcheck(s_eoboards_is_can_mask, type));
 }
 
 
@@ -300,8 +300,8 @@ extern eObool_t eoboards_is_eth(eObrd_type_t type)
     {
         return(eobool_false);
     }
- 
-    return(eo_common_dword_bitcheck(s_eoboards_is_eth_mask, type));       
+
+    return(eo_common_dword_bitcheck(s_eoboards_is_eth_mask, type));
 }
 
 
@@ -310,13 +310,13 @@ extern eObrd_cantype_t eoboards_type2cantype(eObrd_type_t type)
     if(eobool_true == eoboards_is_can(type))
     {
         return((eObrd_cantype_t)type);
-    }  
+    }
 
     if(eobrd_none == type)
     {
         return(eobrd_cantype_none);
     }
-    
+
     return(eobrd_cantype_unknown);
 }
 
@@ -326,13 +326,13 @@ extern eObrd_ethtype_t eoboards_type2ethtype(eObrd_type_t type)
     if(eobool_true == eoboards_is_eth(type))
     {
         return((eObrd_ethtype_t)type);
-    }  
+    }
 
     if(eobrd_none == type)
     {
         return(eobrd_ethtype_none);
     }
-    
+
     return(eobrd_ethtype_unknown);
 }
 
@@ -348,7 +348,7 @@ extern eObrd_type_t eoboards_ethtype2type(eObrd_ethtype_t type)
 
 
 extern eObrd_type_t eoboards_string2type(const char * name)
-{    
+{
     return(eoboards_string2type2(name, eobool_false));
 }
 
@@ -364,8 +364,8 @@ extern eObrd_type_t eoboards_string2type2(const char * string, eObool_t usecompa
     const eOmap_str_str_u08_t * map = s_eoboards_map_of_boards;
     const uint8_t size = eobrd_type_numberof+2;
     const uint8_t defvalue = eobrd_unknown;
-    
-    return((eObrd_type_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));    
+
+    return((eObrd_type_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
 
@@ -375,22 +375,22 @@ extern const char * eoboards_type2string2(eObrd_type_t type, eObool_t usecompact
     const uint8_t size = eobrd_type_numberof+2;
     const uint8_t value = type;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str); 
+
+    return(str);
 }
 
 
 extern eObrd_connector_t eoboards_string2connector(const char * string, eObool_t usecompactstring)
-{    
+{
     const eOmap_str_str_u08_t * map = s_eoboards_map_of_connectors;
     const uint8_t size = eobrd_connectors_numberof+2;
     const uint8_t defvalue = eobrd_conn_unknown;
-    
+
     return((eObrd_connector_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
@@ -401,28 +401,28 @@ extern const char * eoboards_connector2string(eObrd_connector_t connector, eOboo
     const uint8_t size = eobrd_connectors_numberof+2;
     const uint8_t value = connector;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str); 
+
+    return(str);
 }
 
 
 extern eObrd_port_t eoboards_string2port(const char * string, eObool_t usecompactstring)
-{    
+{
     const eOmap_str_str_u08_u08_u08_t * map = s_eoboards_map_of_ports;
     const uint8_t size = eobrd_ports_numberof+2;
-    const uint8_t defvalue = eobrd_port_unknown;    
-    
-    uint8_t i = 0;    
+    const uint8_t defvalue = eobrd_port_unknown;
+
+    uint8_t i = 0;
     if(NULL == string)
     {
         return((eObrd_port_t)defvalue);
     }
-      
+
     for(i=0; i<size; i++)
     {
         const char * str = (eobool_true == usecompactstring) ? map[i].str0 : map[i].str1;
@@ -431,8 +431,8 @@ extern eObrd_port_t eoboards_string2port(const char * string, eObool_t usecompac
             return((eObrd_port_t)map[i].val0);
         }
     }
-    
-    return((eObrd_port_t)defvalue);       
+
+    return((eObrd_port_t)defvalue);
 }
 
 
@@ -455,7 +455,7 @@ extern const char * eoboards_port2string(eObrd_port_t port, eObrd_type_t board, 
         port = eobrd_port_unknown;
         board = eobrd_unknown;
     }
-    
+
     for(i=0; i<size; i++)
     {
         if((value0 == map[i].val0) && (value1 == map[i].val1))
@@ -463,9 +463,9 @@ extern const char * eoboards_port2string(eObrd_port_t port, eObrd_type_t board, 
             const char * str = (eobool_true == usecompactstring) ? map[i].str0 : map[i].str1;
             return(str);
         }
-    }    
-    
-    return((eobool_true == usecompactstring) ? map[size-1].str0 : map[size-1].str1);   
+    }
+
+    return((eobool_true == usecompactstring) ? map[size-1].str0 : map[size-1].str1);
 }
 
 
@@ -487,7 +487,7 @@ extern eObrd_port_t eoboards_connector2port(eObrd_connector_t connector, eObrd_t
         connector = eobrd_conn_unknown;
         board = eobrd_unknown;
     }
-    
+
     for(i=0; i<size; i++)
     {
         if((board == map[i].val1) && (connector == map[i].val2))
@@ -495,8 +495,8 @@ extern eObrd_port_t eoboards_connector2port(eObrd_connector_t connector, eObrd_t
             return((eObrd_port_t)map[i].val0);
         }
     }
-    
-    return((eObrd_port_t)defvalue);               
+
+    return((eObrd_port_t)defvalue);
 }
 
 
@@ -518,8 +518,8 @@ extern eObrd_connector_t eoboards_port2connector(eObrd_port_t port, eObrd_type_t
         port = eobrd_port_unknown;
         board = eobrd_unknown;
     }
-    
-        
+
+
     for(i=0; i<size; i++)
     {
         if((board == map[i].val1) && (port == map[i].val0))
@@ -527,8 +527,8 @@ extern eObrd_connector_t eoboards_port2connector(eObrd_port_t port, eObrd_type_t
             return((eObrd_connector_t)map[i].val2);
         }
     }
-    
-    return((eObrd_connector_t)defvalue);           
+
+    return((eObrd_connector_t)defvalue);
 }
 
 
@@ -538,13 +538,13 @@ extern const char * eoboards_portmais2string(eObrd_portmais_t portmais, eObool_t
     const uint8_t size = eobrd_portmaiss_numberof+2;
     const uint8_t value = portmais;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str);   
+
+    return(str);
 }
 
 
@@ -553,8 +553,8 @@ extern eObrd_portmais_t eoboards_string2portmais(const char * string, eObool_t u
     const eOmap_str_str_u08_t * map = s_boards_map_of_portmaiss;
     const uint8_t size = eobrd_portmaiss_numberof+2;
     const uint8_t defvalue = eobrd_portmais_unknown;
-    
-    return((eObrd_portmais_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+
+    return((eObrd_portmais_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
 
@@ -564,13 +564,13 @@ extern const char * eoboards_portpsc2string(eObrd_portpsc_t portpsc, eObool_t us
     const uint8_t size = eobrd_portpscs_numberof+2;
     const uint8_t value = portpsc;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str);   
+
+    return(str);
 }
 
 
@@ -579,8 +579,8 @@ extern eObrd_portpsc_t eoboards_string2portpsc(const char * string, eObool_t use
     const eOmap_str_str_u08_t * map = s_boards_map_of_portpscs;
     const uint8_t size = eobrd_portpscs_numberof+2;
     const uint8_t defvalue = eobrd_portpsc_unknown;
-    
-    return((eObrd_portpsc_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+
+    return((eObrd_portpsc_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
 
@@ -590,13 +590,13 @@ extern const char * eoboards_portpos2string(eObrd_portpos_t portpos, eObool_t us
     const uint8_t size = eobrd_portposs_numberof+2;
     const uint8_t value = portpos;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str);   
+
+    return(str);
 }
 
 
@@ -605,8 +605,8 @@ extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t use
     const eOmap_str_str_u08_t * map = s_boards_map_of_portposs;
     const uint8_t size = eobrd_portposs_numberof+2;
     const uint8_t defvalue = eobrd_portpos_unknown;
-    
-    return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+
+    return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
 extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mode, eObool_t usecompactstring)
@@ -615,13 +615,13 @@ extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mod
     const uint8_t size = eobrd_reportmodes_numberof+2;
     const uint8_t value = mode;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-    
+
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-    
-    return(str);   
+
+    return(str);
 }
 
 
@@ -630,8 +630,8 @@ extern eObrd_canmonitor_reportmode_t eoboards_string2reportmode(const char * str
     const eOmap_str_str_u08_t * map = s_boards_map_of_reportmodes;
     const uint8_t size = eobrd_reportmodes_numberof+2;
     const uint8_t defvalue = eobrd_canmonitor_reportmode_unknown;
-    
-    return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
+
+    return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
 extern uint8_t eoboards_type2numberofcores(eObrd_type_t type)
@@ -641,13 +641,13 @@ extern uint8_t eoboards_type2numberofcores(eObrd_type_t type)
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - definition of extern hidden functions 
+// - definition of extern hidden functions
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - definition of static functions 
+// - definition of static functions
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -27,7 +27,7 @@
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
 
-#include "stdlib.h"
+#include "stdlib.h" 
 #include "string.h"
 #include "stdio.h"
 
@@ -41,7 +41,7 @@
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - declaration of extern hidden interface
+// - declaration of extern hidden interface 
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 
@@ -68,14 +68,14 @@
 // - definition (and initialisation) of static variables
 // --------------------------------------------------------------------------------------------------------------------
 
-static const uint64_t s_eoboards_is_eth_mask =  (0x1LL << eobrd_ems4) |
-                                                (0x1LL << eobrd_mc4plus) |
+static const uint64_t s_eoboards_is_eth_mask =  (0x1LL << eobrd_ems4) | 
+                                                (0x1LL << eobrd_mc4plus) | 
                                                 (0x1LL << eobrd_mc2plus) |
                                                 (0x1LL << eobrd_amc);
 
-static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
-                                                (0x1LL << eobrd_mtb) |
-                                                (0x1LL << eobrd_strain) |
+static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) | 
+                                                (0x1LL << eobrd_mtb) | 
+                                                (0x1LL << eobrd_strain) |                                                
                                                 (0x1LL << eobrd_mais) |
                                                 (0x1LL << eobrd_foc) |
                                                 (0x1LL << eobrd_dsp) |
@@ -96,25 +96,25 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_mtb4c) |
                                                 (0x1LL << eobrd_mtb4fap) |
                                                 (0x1LL << eobrd_strain2c);
-
-
+       
+   
 static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
-{
+{    
     {"ems4", "eobrd_ems4", eobrd_ems4},
     {"mc4plus", "eobrd_mc4plus", eobrd_mc4plus},
     {"mc2plus", "eobrd_mc2plus", eobrd_mc2plus},
     {"amc", "eobrd_amc", eobrd_amc},
-
+    
     {"mc4", "eobrd_mc4", eobrd_mc4},
     {"mtb", "eobrd_mtb", eobrd_mtb},
     {"strain", "eobrd_strain", eobrd_strain},
     {"mais", "eobrd_mais", eobrd_mais},
     {"foc", "eobrd_foc", eobrd_foc},
-
+    
     {"dsp", "eobrd_dsp", eobrd_dsp},
     {"pic", "eobrd_pic", eobrd_pic},
     {"2dc", "eobrd_2dc", eobrd_2dc},
-    {"bll", "eobrd_bll", eobrd_bll},
+    {"bll", "eobrd_bll", eobrd_bll},    
     {"6sg", "eobrd_6sg", eobrd_6sg},
     {"jog", "eobrd_jog", eobrd_jog},
     {"mtb4", "eobrd_mtb4", eobrd_mtb4},
@@ -129,7 +129,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"mtb4c", "eobrd_mtb4c", eobrd_mtb4c},
     {"mtb4fap", "eobrd_mtb4fap", eobrd_mtb4fap},
     {"strain2c", "eobrd_strain2c", eobrd_strain2c},
-
+    
     {"none", "eobrd_none", eobrd_none},
     {"unknown", "eobrd_unknown", eobrd_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_boards, (eobrd_type_numberof+2)*sizeof(eOmap_str_str_u08_t))
@@ -137,7 +137,7 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
 
 
 static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
-{
+{    
     {"P1", "eobrd_conn_P1",eobrd_conn_P1},
     {"P2", "eobrd_conn_P2", eobrd_conn_P2},
     {"P3", "eobrd_conn_P3", eobrd_conn_P3},
@@ -165,27 +165,37 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"J6", "eobrd_conn_J6", eobrd_conn_J6},
     {"J7", "eobrd_conn_J7", eobrd_conn_J7},
 
+    {"J20", "eobrd_conn_J20", eobrd_conn_J20},
+    {"J21", "eobrd_conn_J21", eobrd_conn_J21},
+    {"J22", "eobrd_conn_J22", eobrd_conn_J22},
+    {"J23", "eobrd_conn_J23", eobrd_conn_J23},
+    
+    {"J30", "eobrd_conn_J30", eobrd_conn_J30},
+    {"J31", "eobrd_conn_J31", eobrd_conn_J31},
+    {"J32", "eobrd_conn_J32", eobrd_conn_J32},
+    {"J33", "eobrd_conn_J33", eobrd_conn_J33},
+    
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_connectors, (eobrd_connectors_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
 static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
-{//  shortname  longname          port value        boardtype   connector
+{//  shortname  longname          port value        boardtype   connector  
     {"emsP6", "eobrd_port_emsP6", eobrd_port_emsP6, eobrd_ems4, eobrd_conn_P6},
     {"emsP7", "eobrd_port_emsP7", eobrd_port_emsP7, eobrd_ems4, eobrd_conn_P7},
     {"emsP8", "eobrd_port_emsP8", eobrd_port_emsP8, eobrd_ems4, eobrd_conn_P8},
     {"emsP9", "eobrd_port_emsP9", eobrd_port_emsP9, eobrd_ems4, eobrd_conn_P9},
     {"emsP10", "eobrd_port_emsP10", eobrd_port_emsP10, eobrd_ems4, eobrd_conn_P10},
     {"emsP11", "eobrd_port_emsP11", eobrd_port_emsP11, eobrd_ems4, eobrd_conn_P11},
-
+    
     {"mc4plusP2", "eobrd_port_mc4plusP2", eobrd_port_mc4plusP2, eobrd_mc4plus, eobrd_conn_P2},
     {"mc4plusP3", "eobrd_port_mc4plusP3", eobrd_port_mc4plusP3, eobrd_mc4plus, eobrd_conn_P3},
     {"mc4plusP4", "eobrd_port_mc4plusP4", eobrd_port_mc4plusP4, eobrd_mc4plus, eobrd_conn_P4},
     {"mc4plusP5", "eobrd_port_mc4plusP5", eobrd_port_mc4plusP5, eobrd_mc4plus, eobrd_conn_P5},
     {"mc4plusP10", "eobrd_port_mc4plusP10", eobrd_port_mc4plusP10, eobrd_mc4plus, eobrd_conn_P10},
     {"mc4plusP11", "eobrd_port_mc4plusP11", eobrd_port_mc4plusP11, eobrd_mc4plus, eobrd_conn_P11},
-
+    
     {"mc2plusP2", "eobrd_port_mc2plusP2", eobrd_port_mc2plusP2, eobrd_mc2plus, eobrd_conn_P2},
     {"mc2plusP3", "eobrd_port_mc2plusP3", eobrd_port_mc2plusP3, eobrd_mc2plus, eobrd_conn_P3},
     {"mc2plusP10", "eobrd_port_mc2plusP10", eobrd_port_mc2plusP10, eobrd_mc2plus, eobrd_conn_P10},
@@ -194,7 +204,7 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"amcJ5_X1", "eobrd_port_amc_J5_X1", eobrd_port_amc_J5_X1, eobrd_amc, eobrd_conn_J5_X1},
     {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
     {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
-
+    
     {"mtb4fap_J3_SDA0", "eobrd_port_mtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
     {"mtb4fap_J3_SDA1", "eobrd_port_mtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
     {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
@@ -214,7 +224,37 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"pmc_J5", "eobrd_port_pmc_J5", eobrd_port_pmc_J5, eobrd_pmc, eobrd_conn_J5},
     {"pmc_J6", "eobrd_port_pmc_J6", eobrd_port_pmc_J6, eobrd_pmc, eobrd_conn_J6},
     {"pmc_J7", "eobrd_port_pmc_J7", eobrd_port_pmc_J7, eobrd_pmc, eobrd_conn_J7},
+    
+    {"mtb4fap_mmaJ20", "eobrd_port_mtb4fap_mmaJ20", eobrd_port_mtb4fap_mmaJ20, eobrd_mtb4fap, eobrd_conn_J20},
+    {"mtb4fap_mmaJ21", "eobrd_port_mtb4fap_mmaJ21", eobrd_port_mtb4fap_mmaJ21, eobrd_mtb4fap, eobrd_conn_J21},
+    {"mtb4fap_mmaJ22", "eobrd_port_mtb4fap_mmaJ22", eobrd_port_mtb4fap_mmaJ22, eobrd_mtb4fap, eobrd_conn_J22},
+    {"mtb4fap_mmaJ23", "eobrd_port_mtb4fap_mmaJ23", eobrd_port_mtb4fap_mmaJ23, eobrd_mtb4fap, eobrd_conn_J23},
+    
+    {"mtb4_mmaJ20", "eobrd_port_mtb4_mmaJ20", eobrd_port_mtb4_mmaJ20, eobrd_mtb4, eobrd_conn_J20},
+    {"mtb4_mmaJ21", "eobrd_port_mtb4_mmaJ21", eobrd_port_mtb4_mmaJ21, eobrd_mtb4, eobrd_conn_J21},
+    {"mtb4_mmaJ22", "eobrd_port_mtb4_mmaJ22", eobrd_port_mtb4_mmaJ22, eobrd_mtb4, eobrd_conn_J22},
+    {"mtb4_mmaJ23", "eobrd_port_mtb4_mmaJ23", eobrd_port_mtb4_mmaJ23, eobrd_mtb4, eobrd_conn_J23},
 
+    {"mtb4c_mmaJ20", "eobrd_port_mtb4c_mmaJ20", eobrd_port_mtb4c_mmaJ20, eobrd_mtb4c, eobrd_conn_J20},
+    {"mtb4c_mmaJ21", "eobrd_port_mtb4c_mmaJ21", eobrd_port_mtb4c_mmaJ21, eobrd_mtb4c, eobrd_conn_J21},
+    {"mtb4c_mmaJ22", "eobrd_port_mtb4c_mmaJ22", eobrd_port_mtb4c_mmaJ22, eobrd_mtb4c, eobrd_conn_J22},
+    {"mtb4c_mmaJ23", "eobrd_port_mtb4c_mmaJ23", eobrd_port_mtb4c_mmaJ23, eobrd_mtb4c, eobrd_conn_J23},
+
+    {"mtb4fap_mmaJ30", "eobrd_port_mtb4fap_mmaJ30", eobrd_port_mtb4fap_mmaJ30, eobrd_mtb4fap, eobrd_conn_J30},
+    {"mtb4fap_mmaJ31", "eobrd_port_mtb4fap_mmaJ31", eobrd_port_mtb4fap_mmaJ31, eobrd_mtb4fap, eobrd_conn_J31},
+    {"mtb4fap_mmaJ32", "eobrd_port_mtb4fap_mmaJ32", eobrd_port_mtb4fap_mmaJ32, eobrd_mtb4fap, eobrd_conn_J32},
+    {"mtb4fap_mmaJ33", "eobrd_port_mtb4fap_mmaJ33", eobrd_port_mtb4fap_mmaJ33, eobrd_mtb4fap, eobrd_conn_J33},
+    
+    {"mtb4_mmaJ30", "eobrd_port_mtb4_mmaJ30", eobrd_port_mtb4_mmaJ30, eobrd_mtb4, eobrd_conn_J30},
+    {"mtb4_mmaJ31", "eobrd_port_mtb4_mmaJ31", eobrd_port_mtb4_mmaJ31, eobrd_mtb4, eobrd_conn_J31},
+    {"mtb4_mmaJ32", "eobrd_port_mtb4_mmaJ32", eobrd_port_mtb4_mmaJ32, eobrd_mtb4, eobrd_conn_J32},
+    {"mtb4_mmaJ33", "eobrd_port_mtb4_mmaJ33", eobrd_port_mtb4_mmaJ33, eobrd_mtb4, eobrd_conn_J33},
+
+    {"mtb4c_mmaJ30", "eobrd_port_mtb4c_mmaJ30", eobrd_port_mtb4c_mmaJ30, eobrd_mtb4c, eobrd_conn_J30},
+    {"mtb4c_mmaJ31", "eobrd_port_mtb4c_mmaJ31", eobrd_port_mtb4c_mmaJ31, eobrd_mtb4c, eobrd_conn_J31},
+    {"mtb4c_mmaJ32", "eobrd_port_mtb4c_mmaJ32", eobrd_port_mtb4c_mmaJ32, eobrd_mtb4c, eobrd_conn_J32},
+    {"mtb4c_mmaJ33", "eobrd_port_mtb4c_mmaJ33", eobrd_port_mtb4c_mmaJ33, eobrd_mtb4c, eobrd_conn_J33},
+    
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_ports, (eobrd_ports_numberof+2)*sizeof(eOmap_str_str_u08_u08_u08_t))
@@ -229,9 +269,9 @@ static const eOmap_str_str_u08_t s_boards_map_of_portmaiss[] =
     {"mediumproximal", "eobrd_portmais_mediumproximal", eobrd_portmais_mediumproximal},
     {"mediumdistal", "eobrd_portmais_mediumdistal", eobrd_portmais_mediumdistal},
     {"littlefingers", "eobrd_portmais_littlefingers", eobrd_portmais_littlefingers},
-
+    
     {"none", "eobrd_portmais_none", eobrd_portmais_none},
-    {"unknown", "eobrd_portmais_unknown", eobrd_portmais_unknown}
+    {"unknown", "eobrd_portmais_unknown", eobrd_portmais_unknown}    
 };  EO_VERIFYsizeof(s_boards_map_of_portmaiss, (eobrd_portmaiss_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -239,9 +279,9 @@ static const eOmap_str_str_u08_t s_boards_map_of_portpscs[] =
 {
     {"finger0", "eobrd_portpsc_finger0", eobrd_portpsc_finger0},
     {"finger1", "eobrd_portpsc_finger1", eobrd_portpsc_finger1},
-
+    
     {"none", "eobrd_portpsc_none", eobrd_portpsc_none},
-    {"unknown", "eobrd_portpsc_unknown", eobrd_portpsc_unknown}
+    {"unknown", "eobrd_portpsc_unknown", eobrd_portpsc_unknown}    
 };  EO_VERIFYsizeof(s_boards_map_of_portpscs, (eobrd_portpscs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -251,12 +291,12 @@ static const eOmap_str_str_u08_t s_boards_map_of_portposs[] =
     {"hand_index_oc", "eobrd_portpos_hand_index_oc", eobrd_portpos_hand_index_oc},
     {"hand_middle_oc", "eobrd_portpos_hand_middle_oc", eobrd_portpos_hand_middle_oc},
     {"hand_ring_pinky_oc", "eobrd_portpos_hand_ring_pinky_oc", eobrd_portpos_hand_ring_pinky_oc},
-    {"hand_thumb_add", "eobrd_portpos_hand_thumb_add", eobrd_portpos_hand_thumb_add},
-    {"hand_thumbrotation", "eobrd_portpos_hand_thumbrotation", eobrd_portpos_hand_thumbrotation},
+    {"hand_hand_thumb_add", "eobrd_portpos_hand_thumb_add", eobrd_portpos_hand_thumb_add},
+    {"hand_tbd", "eobrd_portpos_hand_tbd", eobrd_portpos_hand_tbd},
     {"hand_index_add", "eobrd_portpos_hand_index_add", eobrd_portpos_hand_index_add},
-
+    
     {"none", "eobrd_portpos_none", eobrd_portpos_none},
-    {"unknown", "eobrd_portpos_unknown", eobrd_portpos_unknown}
+    {"unknown", "eobrd_portpos_unknown", eobrd_portpos_unknown}    
 };  EO_VERIFYsizeof(s_boards_map_of_portposs, (eobrd_portposs_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -268,7 +308,7 @@ static const eOmap_str_str_u08_t s_boards_map_of_reportmodes[] =
     {"ALL", "eobrd_canmonitor_reportmode_ALL", eobrd_canmonitor_reportmode_ALL},
 
     {"none", "eobrd_canmonitor_reportmode_none", eobrd_canmonitor_reportmode_none},
-    {"unknown", "eobrd_canmonitor_reportmode_unknown", eobrd_canmonitor_reportmode_unknown}
+    {"unknown", "eobrd_canmonitor_reportmode_unknown", eobrd_canmonitor_reportmode_unknown}    
 };  EO_VERIFYsizeof(s_boards_map_of_reportmodes, (eobrd_reportmodes_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
 
@@ -289,8 +329,8 @@ extern eObool_t eoboards_is_can(eObrd_type_t type)
     {
         return(eobool_false);
     }
-
-    return(eo_common_dword_bitcheck(s_eoboards_is_can_mask, type));
+ 
+    return(eo_common_dword_bitcheck(s_eoboards_is_can_mask, type));      
 }
 
 
@@ -300,8 +340,8 @@ extern eObool_t eoboards_is_eth(eObrd_type_t type)
     {
         return(eobool_false);
     }
-
-    return(eo_common_dword_bitcheck(s_eoboards_is_eth_mask, type));
+ 
+    return(eo_common_dword_bitcheck(s_eoboards_is_eth_mask, type));       
 }
 
 
@@ -310,13 +350,13 @@ extern eObrd_cantype_t eoboards_type2cantype(eObrd_type_t type)
     if(eobool_true == eoboards_is_can(type))
     {
         return((eObrd_cantype_t)type);
-    }
+    }  
 
     if(eobrd_none == type)
     {
         return(eobrd_cantype_none);
     }
-
+    
     return(eobrd_cantype_unknown);
 }
 
@@ -326,13 +366,13 @@ extern eObrd_ethtype_t eoboards_type2ethtype(eObrd_type_t type)
     if(eobool_true == eoboards_is_eth(type))
     {
         return((eObrd_ethtype_t)type);
-    }
+    }  
 
     if(eobrd_none == type)
     {
         return(eobrd_ethtype_none);
     }
-
+    
     return(eobrd_ethtype_unknown);
 }
 
@@ -348,7 +388,7 @@ extern eObrd_type_t eoboards_ethtype2type(eObrd_ethtype_t type)
 
 
 extern eObrd_type_t eoboards_string2type(const char * name)
-{
+{    
     return(eoboards_string2type2(name, eobool_false));
 }
 
@@ -364,8 +404,8 @@ extern eObrd_type_t eoboards_string2type2(const char * string, eObool_t usecompa
     const eOmap_str_str_u08_t * map = s_eoboards_map_of_boards;
     const uint8_t size = eobrd_type_numberof+2;
     const uint8_t defvalue = eobrd_unknown;
-
-    return((eObrd_type_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
+    
+    return((eObrd_type_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));    
 }
 
 
@@ -375,22 +415,22 @@ extern const char * eoboards_type2string2(eObrd_type_t type, eObool_t usecompact
     const uint8_t size = eobrd_type_numberof+2;
     const uint8_t value = type;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str); 
 }
 
 
 extern eObrd_connector_t eoboards_string2connector(const char * string, eObool_t usecompactstring)
-{
+{    
     const eOmap_str_str_u08_t * map = s_eoboards_map_of_connectors;
     const uint8_t size = eobrd_connectors_numberof+2;
     const uint8_t defvalue = eobrd_conn_unknown;
-
+    
     return((eObrd_connector_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
 }
 
@@ -401,28 +441,28 @@ extern const char * eoboards_connector2string(eObrd_connector_t connector, eOboo
     const uint8_t size = eobrd_connectors_numberof+2;
     const uint8_t value = connector;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str); 
 }
 
 
 extern eObrd_port_t eoboards_string2port(const char * string, eObool_t usecompactstring)
-{
+{    
     const eOmap_str_str_u08_u08_u08_t * map = s_eoboards_map_of_ports;
     const uint8_t size = eobrd_ports_numberof+2;
-    const uint8_t defvalue = eobrd_port_unknown;
-
-    uint8_t i = 0;
+    const uint8_t defvalue = eobrd_port_unknown;    
+    
+    uint8_t i = 0;    
     if(NULL == string)
     {
         return((eObrd_port_t)defvalue);
     }
-
+      
     for(i=0; i<size; i++)
     {
         const char * str = (eobool_true == usecompactstring) ? map[i].str0 : map[i].str1;
@@ -431,8 +471,8 @@ extern eObrd_port_t eoboards_string2port(const char * string, eObool_t usecompac
             return((eObrd_port_t)map[i].val0);
         }
     }
-
-    return((eObrd_port_t)defvalue);
+    
+    return((eObrd_port_t)defvalue);       
 }
 
 
@@ -455,7 +495,7 @@ extern const char * eoboards_port2string(eObrd_port_t port, eObrd_type_t board, 
         port = eobrd_port_unknown;
         board = eobrd_unknown;
     }
-
+    
     for(i=0; i<size; i++)
     {
         if((value0 == map[i].val0) && (value1 == map[i].val1))
@@ -463,9 +503,9 @@ extern const char * eoboards_port2string(eObrd_port_t port, eObrd_type_t board, 
             const char * str = (eobool_true == usecompactstring) ? map[i].str0 : map[i].str1;
             return(str);
         }
-    }
-
-    return((eobool_true == usecompactstring) ? map[size-1].str0 : map[size-1].str1);
+    }    
+    
+    return((eobool_true == usecompactstring) ? map[size-1].str0 : map[size-1].str1);   
 }
 
 
@@ -487,7 +527,7 @@ extern eObrd_port_t eoboards_connector2port(eObrd_connector_t connector, eObrd_t
         connector = eobrd_conn_unknown;
         board = eobrd_unknown;
     }
-
+    
     for(i=0; i<size; i++)
     {
         if((board == map[i].val1) && (connector == map[i].val2))
@@ -495,8 +535,8 @@ extern eObrd_port_t eoboards_connector2port(eObrd_connector_t connector, eObrd_t
             return((eObrd_port_t)map[i].val0);
         }
     }
-
-    return((eObrd_port_t)defvalue);
+    
+    return((eObrd_port_t)defvalue);               
 }
 
 
@@ -518,8 +558,8 @@ extern eObrd_connector_t eoboards_port2connector(eObrd_port_t port, eObrd_type_t
         port = eobrd_port_unknown;
         board = eobrd_unknown;
     }
-
-
+    
+        
     for(i=0; i<size; i++)
     {
         if((board == map[i].val1) && (port == map[i].val0))
@@ -527,8 +567,8 @@ extern eObrd_connector_t eoboards_port2connector(eObrd_port_t port, eObrd_type_t
             return((eObrd_connector_t)map[i].val2);
         }
     }
-
-    return((eObrd_connector_t)defvalue);
+    
+    return((eObrd_connector_t)defvalue);           
 }
 
 
@@ -538,13 +578,13 @@ extern const char * eoboards_portmais2string(eObrd_portmais_t portmais, eObool_t
     const uint8_t size = eobrd_portmaiss_numberof+2;
     const uint8_t value = portmais;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str);   
 }
 
 
@@ -553,8 +593,8 @@ extern eObrd_portmais_t eoboards_string2portmais(const char * string, eObool_t u
     const eOmap_str_str_u08_t * map = s_boards_map_of_portmaiss;
     const uint8_t size = eobrd_portmaiss_numberof+2;
     const uint8_t defvalue = eobrd_portmais_unknown;
-
-    return((eObrd_portmais_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
+    
+    return((eObrd_portmais_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 
@@ -564,13 +604,13 @@ extern const char * eoboards_portpsc2string(eObrd_portpsc_t portpsc, eObool_t us
     const uint8_t size = eobrd_portpscs_numberof+2;
     const uint8_t value = portpsc;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str);   
 }
 
 
@@ -579,8 +619,8 @@ extern eObrd_portpsc_t eoboards_string2portpsc(const char * string, eObool_t use
     const eOmap_str_str_u08_t * map = s_boards_map_of_portpscs;
     const uint8_t size = eobrd_portpscs_numberof+2;
     const uint8_t defvalue = eobrd_portpsc_unknown;
-
-    return((eObrd_portpsc_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
+    
+    return((eObrd_portpsc_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 
@@ -590,13 +630,13 @@ extern const char * eoboards_portpos2string(eObrd_portpos_t portpos, eObool_t us
     const uint8_t size = eobrd_portposs_numberof+2;
     const uint8_t value = portpos;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str);   
 }
 
 
@@ -605,8 +645,8 @@ extern eObrd_portpos_t eoboards_string2portpos(const char * string, eObool_t use
     const eOmap_str_str_u08_t * map = s_boards_map_of_portposs;
     const uint8_t size = eobrd_portposs_numberof+2;
     const uint8_t defvalue = eobrd_portpos_unknown;
-
-    return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
+    
+    return((eObrd_portpos_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mode, eObool_t usecompactstring)
@@ -615,13 +655,13 @@ extern const char * eoboards_reportmode2string(eObrd_canmonitor_reportmode_t mod
     const uint8_t size = eobrd_reportmodes_numberof+2;
     const uint8_t value = mode;
     const char * str = eo_common_map_str_str_u08__value2string(map, size, value, usecompactstring);
-
+    
     if(NULL == str)
     {
         str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
     }
-
-    return(str);
+    
+    return(str);   
 }
 
 
@@ -630,8 +670,8 @@ extern eObrd_canmonitor_reportmode_t eoboards_string2reportmode(const char * str
     const eOmap_str_str_u08_t * map = s_boards_map_of_reportmodes;
     const uint8_t size = eobrd_reportmodes_numberof+2;
     const uint8_t defvalue = eobrd_canmonitor_reportmode_unknown;
-
-    return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));
+    
+    return((eObrd_canmonitor_reportmode_t)eo_common_map_str_str_u08__string2value(map, size, string, usecompactstring, defvalue));        
 }
 
 extern uint8_t eoboards_type2numberofcores(eObrd_type_t type)
@@ -641,13 +681,13 @@ extern uint8_t eoboards_type2numberofcores(eObrd_type_t type)
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - definition of extern hidden functions
+// - definition of extern hidden functions 
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 
 
 // --------------------------------------------------------------------------------------------------------------------
-// - definition of static functions
+// - definition of static functions 
 // --------------------------------------------------------------------------------------------------------------------
 // empty-section
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -307,13 +307,21 @@ typedef enum
     eobrd_conn_J4       = 23,
     eobrd_conn_J5       = 24,
     eobrd_conn_J6       = 25,
-    eobrd_conn_J7       = 26,   
+    eobrd_conn_J7       = 26,  
+    eobrd_conn_J20      = 27,
+    eobrd_conn_J21      = 28,
+    eobrd_conn_J22      = 29,
+    eobrd_conn_J23      = 30,    
+    eobrd_conn_J30      = 31,
+    eobrd_conn_J31      = 32,
+    eobrd_conn_J32      = 33,
+    eobrd_conn_J33      = 34,
     
     eobrd_conn_none     = 0,
     eobrd_conn_unknown  = 255
 } eObrd_connector_t;
 
-enum { eobrd_connectors_numberof = 26 };
+enum { eobrd_connectors_numberof = 34 };
 
 
 typedef enum
@@ -363,11 +371,42 @@ typedef enum
     eobrd_port_pmc_J4               = 0,        // I2C1 
     eobrd_port_pmc_J5               = 1,        // I2C2
     eobrd_port_pmc_J6               = 2,        // I2C3
-    eobrd_port_pmc_J7               = 3         // I2C4 
+    eobrd_port_pmc_J7               = 3,        // I2C4 
+
+    eobrd_port_mtb4fap_mmaJ20       = 0,
+    eobrd_port_mtb4fap_mmaJ21       = 1,
+    eobrd_port_mtb4fap_mmaJ22       = 2,
+    eobrd_port_mtb4fap_mmaJ23       = 3,   
+    
+    eobrd_port_mtb4_mmaJ20          = 0,
+    eobrd_port_mtb4_mmaJ21          = 1,
+    eobrd_port_mtb4_mmaJ22          = 2,
+    eobrd_port_mtb4_mmaJ23          = 3,      
+
+    eobrd_port_mtb4c_mmaJ20         = 0,
+    eobrd_port_mtb4c_mmaJ21         = 1,
+    eobrd_port_mtb4c_mmaJ22         = 2,
+    eobrd_port_mtb4c_mmaJ23         = 3,
+
+    eobrd_port_mtb4fap_mmaJ30       = 0,
+    eobrd_port_mtb4fap_mmaJ31       = 1,
+    eobrd_port_mtb4fap_mmaJ32       = 2,
+    eobrd_port_mtb4fap_mmaJ33       = 3,   
+    
+    eobrd_port_mtb4_mmaJ30          = 0,
+    eobrd_port_mtb4_mmaJ31          = 1,
+    eobrd_port_mtb4_mmaJ32          = 2,
+    eobrd_port_mtb4_mmaJ33          = 3,      
+
+    eobrd_port_mtb4c_mmaJ30         = 0,
+    eobrd_port_mtb4c_mmaJ31         = 1,
+    eobrd_port_mtb4c_mmaJ32         = 2,
+    eobrd_port_mtb4c_mmaJ33         = 3
+       
     
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 35 };
+enum { eobrd_ports_numberof = 59 };
 
 
 typedef enum
@@ -400,13 +439,13 @@ enum { eobrd_portpscs_numberof = 2 };
 
 typedef enum
 {
-    eobrd_portpos_hand_thumb            = 0,
-    eobrd_portpos_hand_index            = 1,
-    eobrd_portpos_hand_medium           = 2,
-    eobrd_portpos_hand_pinky            = 3,
-    eobrd_portpos_hand_thumbmetacarpus  = 4,
-    eobrd_portpos_hand_thumbrotation    = 5,
-    eobrd_portpos_hand_indexadduction   = 6,
+    eobrd_portpos_hand_thumb_oc         = 0,
+    eobrd_portpos_hand_index_oc         = 1,
+    eobrd_portpos_hand_middle_oc        = 2,
+    eobrd_portpos_hand_ring_pinky_oc    = 3,
+    eobrd_portpos_hand_thumb_add        = 4,
+    eobrd_portpos_hand_tbd              = 5,
+    eobrd_portpos_hand_index_add        = 6,    
     
     eobrd_portpos_none                  = 31,    // as ... eobrd_port_none
     eobrd_portpos_unknown               = 30     // as ... eobrd_port_unknown


### PR DESCRIPTION
See robotology/robots-configuration#436

(unfortunately VS Code cleaned up the trailing space, I advice to review the changes ticking "[Hide whitespace](https://github.com/robotology/icub-firmware-shared/pull/78/files?w=1)")

TO BE TESTED

