### PR TITLE
FAP reading for `mtb4` and `mtb4c` 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.31.0)
+        VERSION 1.32.0)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -200,6 +200,11 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
     {"mtb4fap_J3_SDA3", "eobrd_port_mtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
 
+    {"mtb4c_J3_SDA0", "eobrd_port_mtb4c_J3_SDA0", eobrd_port_mtb4c_J3_SDA0, eobrd_mtb4c, eobrd_conn_J3_SDA0},
+    {"mtb4c_J3_SDA1", "eobrd_port_mtb4c_J3_SDA1", eobrd_port_mtb4c_J3_SDA1, eobrd_mtb4c, eobrd_conn_J3_SDA1},
+    {"mtb4c_J3_SDA2", "eobrd_port_mtb4c_J3_SDA2", eobrd_port_mtb4c_J3_SDA2, eobrd_mtb4c, eobrd_conn_J3_SDA2},
+    {"mtb4c_J3_SDA3", "eobrd_port_mtb4c_J3_SDA3", eobrd_port_mtb4c_J3_SDA3, eobrd_mtb4c, eobrd_conn_J3_SDA3},
+
     {"pmc_J4", "eobrd_port_pmc_J4", eobrd_port_pmc_J4, eobrd_pmc, eobrd_conn_J4},
     {"pmc_J5", "eobrd_port_pmc_J5", eobrd_port_pmc_J5, eobrd_pmc, eobrd_conn_J5},
     {"pmc_J6", "eobrd_port_pmc_J6", eobrd_port_pmc_J6, eobrd_pmc, eobrd_conn_J6},

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -200,6 +200,11 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
     {"mtb4fap_J3_SDA3", "eobrd_port_mtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
 
+    {"mtb4_J3_SDA0", "eobrd_port_mtb4_J3_SDA0", eobrd_port_mtb4_J3_SDA0, eobrd_mtb4, eobrd_conn_J3_SDA0},
+    {"mtb4_J3_SDA1", "eobrd_port_mtb4_J3_SDA1", eobrd_port_mtb4_J3_SDA1, eobrd_mtb4, eobrd_conn_J3_SDA1},
+    {"mtb4_J3_SDA2", "eobrd_port_mtb4_J3_SDA2", eobrd_port_mtb4_J3_SDA2, eobrd_mtb4, eobrd_conn_J3_SDA2},
+    {"mtb4_J3_SDA3", "eobrd_port_mtb4_J3_SDA3", eobrd_port_mtb4_J3_SDA3, eobrd_mtb4, eobrd_conn_J3_SDA3},
+    
     {"mtb4c_J3_SDA0", "eobrd_port_mtb4c_J3_SDA0", eobrd_port_mtb4c_J3_SDA0, eobrd_mtb4c, eobrd_conn_J3_SDA0},
     {"mtb4c_J3_SDA1", "eobrd_port_mtb4c_J3_SDA1", eobrd_port_mtb4c_J3_SDA1, eobrd_mtb4c, eobrd_conn_J3_SDA1},
     {"mtb4c_J3_SDA2", "eobrd_port_mtb4c_J3_SDA2", eobrd_port_mtb4c_J3_SDA2, eobrd_mtb4c, eobrd_conn_J3_SDA2},

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -349,6 +349,11 @@ typedef enum
     eobrd_port_mtb4fap_J3_SDA1      = 1,
     eobrd_port_mtb4fap_J3_SDA2      = 2,
     eobrd_port_mtb4fap_J3_SDA3      = 3,  
+
+    eobrd_port_mtb4c_J3_SDA0        = 0,
+    eobrd_port_mtb4c_J3_SDA1        = 1,
+    eobrd_port_mtb4c_J3_SDA2        = 2,
+    eobrd_port_mtb4c_J3_SDA3        = 3,  
     
     eobrd_port_pmc_J4               = 0,        // I2C1 
     eobrd_port_pmc_J5               = 1,        // I2C2
@@ -357,7 +362,7 @@ typedef enum
     
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 27 };
+enum { eobrd_ports_numberof = 31 };
 
 
 typedef enum

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -350,6 +350,11 @@ typedef enum
     eobrd_port_mtb4fap_J3_SDA2      = 2,
     eobrd_port_mtb4fap_J3_SDA3      = 3,  
 
+    eobrd_port_mtb4_J3_SDA0         = 0,
+    eobrd_port_mtb4_J3_SDA1         = 1,
+    eobrd_port_mtb4_J3_SDA2         = 2,
+    eobrd_port_mtb4_J3_SDA3         = 3,  
+    
     eobrd_port_mtb4c_J3_SDA0        = 0,
     eobrd_port_mtb4c_J3_SDA1        = 1,
     eobrd_port_mtb4c_J3_SDA2        = 2,
@@ -362,7 +367,7 @@ typedef enum
     
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 31 };
+enum { eobrd_ports_numberof = 35 };
 
 
 typedef enum


### PR DESCRIPTION
This PR is linked to https://github.com/robotology/icub-firmware/pull/347 and allows the extension of the POS service to the boards `mtb4` and `mtb4c`.
