### PR TITLE
Removal of `mtb4fap` board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.33.0)
+        VERSION 1.33.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/can/canProtocolLib/iCubCanProto_types.h
+++ b/can/canProtocolLib/iCubCanProto_types.h
@@ -78,7 +78,7 @@ extern "C" {
 #define ICUBCANPROTO_BOARDTYPE__AMCBLDC 18
 #define ICUBCANPROTO_BOARDTYPE__BMS     19
 #define ICUBCANPROTO_BOARDTYPE__MTB4C   20
-#define ICUBCANPROTO_BOARDTYPE__MTB4FAP 21
+#define ICUBCANPROTO_BOARDTYPE__FFU     21
 #define ICUBCANPROTO_BOARDTYPE__STRAIN2C 22
 #define ICUBCANPROTO_BOARDTYPE__UNKNOWN 255
 
@@ -117,7 +117,6 @@ typedef enum
     icubCanProto_boardType__amcbldc = ICUBCANPROTO_BOARDTYPE__AMCBLDC,
     icubCanProto_boardType__bms     = ICUBCANPROTO_BOARDTYPE__BMS,
     icubCanProto_boardType__mtb4c   = ICUBCANPROTO_BOARDTYPE__MTB4C,
-    icubCanProto_boardType__mtb4fap = ICUBCANPROTO_BOARDTYPE__MTB4FAP,
     icubCanProto_boardType__strain2c = ICUBCANPROTO_BOARDTYPE__STRAIN2C,
     icubCanProto_boardType__unknown = ICUBCANPROTO_BOARDTYPE__UNKNOWN
 } icubCanProto_boardType_t;

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -94,7 +94,6 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_amcbldc)|
                                                 (0x1LL << eobrd_bms)|
                                                 (0x1LL << eobrd_mtb4c) |
-                                                (0x1LL << eobrd_mtb4fap) |
                                                 (0x1LL << eobrd_strain2c);
        
    
@@ -127,7 +126,6 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
     {"amcbldc", "eobrd_amcbldc", eobrd_amcbldc},
     {"bms", "eobrd_bms", eobrd_bms},
     {"mtb4c", "eobrd_mtb4c", eobrd_mtb4c},
-    {"mtb4fap", "eobrd_mtb4fap", eobrd_mtb4fap},
     {"strain2c", "eobrd_strain2c", eobrd_strain2c},
     
     {"none", "eobrd_none", eobrd_none},
@@ -205,11 +203,6 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"amcJ5_X2", "eobrd_port_amc_J5_X2", eobrd_port_amc_J5_X2, eobrd_amc, eobrd_conn_J5_X2},
     {"amcJ5_X3", "eobrd_port_amc_J5_X3", eobrd_port_amc_J5_X3, eobrd_amc, eobrd_conn_J5_X3},
     
-    {"mtb4fap_J3_SDA0", "eobrd_port_mtb4fap_J3_SDA0", eobrd_port_mtb4fap_J3_SDA0, eobrd_mtb4fap, eobrd_conn_J3_SDA0},
-    {"mtb4fap_J3_SDA1", "eobrd_port_mtb4fap_J3_SDA1", eobrd_port_mtb4fap_J3_SDA1, eobrd_mtb4fap, eobrd_conn_J3_SDA1},
-    {"mtb4fap_J3_SDA2", "eobrd_port_mtb4fap_J3_SDA2", eobrd_port_mtb4fap_J3_SDA2, eobrd_mtb4fap, eobrd_conn_J3_SDA2},
-    {"mtb4fap_J3_SDA3", "eobrd_port_mtb4fap_J3_SDA3", eobrd_port_mtb4fap_J3_SDA3, eobrd_mtb4fap, eobrd_conn_J3_SDA3},
-
     {"mtb4_J3_SDA0", "eobrd_port_mtb4_J3_SDA0", eobrd_port_mtb4_J3_SDA0, eobrd_mtb4, eobrd_conn_J3_SDA0},
     {"mtb4_J3_SDA1", "eobrd_port_mtb4_J3_SDA1", eobrd_port_mtb4_J3_SDA1, eobrd_mtb4, eobrd_conn_J3_SDA1},
     {"mtb4_J3_SDA2", "eobrd_port_mtb4_J3_SDA2", eobrd_port_mtb4_J3_SDA2, eobrd_mtb4, eobrd_conn_J3_SDA2},
@@ -224,12 +217,7 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"pmc_J5", "eobrd_port_pmc_J5", eobrd_port_pmc_J5, eobrd_pmc, eobrd_conn_J5},
     {"pmc_J6", "eobrd_port_pmc_J6", eobrd_port_pmc_J6, eobrd_pmc, eobrd_conn_J6},
     {"pmc_J7", "eobrd_port_pmc_J7", eobrd_port_pmc_J7, eobrd_pmc, eobrd_conn_J7},
-    
-    {"mtb4fap_mmaJ20", "eobrd_port_mtb4fap_mmaJ20", eobrd_port_mtb4fap_mmaJ20, eobrd_mtb4fap, eobrd_conn_J20},
-    {"mtb4fap_mmaJ21", "eobrd_port_mtb4fap_mmaJ21", eobrd_port_mtb4fap_mmaJ21, eobrd_mtb4fap, eobrd_conn_J21},
-    {"mtb4fap_mmaJ22", "eobrd_port_mtb4fap_mmaJ22", eobrd_port_mtb4fap_mmaJ22, eobrd_mtb4fap, eobrd_conn_J22},
-    {"mtb4fap_mmaJ23", "eobrd_port_mtb4fap_mmaJ23", eobrd_port_mtb4fap_mmaJ23, eobrd_mtb4fap, eobrd_conn_J23},
-    
+        
     {"mtb4_mmaJ20", "eobrd_port_mtb4_mmaJ20", eobrd_port_mtb4_mmaJ20, eobrd_mtb4, eobrd_conn_J20},
     {"mtb4_mmaJ21", "eobrd_port_mtb4_mmaJ21", eobrd_port_mtb4_mmaJ21, eobrd_mtb4, eobrd_conn_J21},
     {"mtb4_mmaJ22", "eobrd_port_mtb4_mmaJ22", eobrd_port_mtb4_mmaJ22, eobrd_mtb4, eobrd_conn_J22},
@@ -239,11 +227,6 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mtb4c_mmaJ21", "eobrd_port_mtb4c_mmaJ21", eobrd_port_mtb4c_mmaJ21, eobrd_mtb4c, eobrd_conn_J21},
     {"mtb4c_mmaJ22", "eobrd_port_mtb4c_mmaJ22", eobrd_port_mtb4c_mmaJ22, eobrd_mtb4c, eobrd_conn_J22},
     {"mtb4c_mmaJ23", "eobrd_port_mtb4c_mmaJ23", eobrd_port_mtb4c_mmaJ23, eobrd_mtb4c, eobrd_conn_J23},
-
-    {"mtb4fap_mmaJ30", "eobrd_port_mtb4fap_mmaJ30", eobrd_port_mtb4fap_mmaJ30, eobrd_mtb4fap, eobrd_conn_J30},
-    {"mtb4fap_mmaJ31", "eobrd_port_mtb4fap_mmaJ31", eobrd_port_mtb4fap_mmaJ31, eobrd_mtb4fap, eobrd_conn_J31},
-    {"mtb4fap_mmaJ32", "eobrd_port_mtb4fap_mmaJ32", eobrd_port_mtb4fap_mmaJ32, eobrd_mtb4fap, eobrd_conn_J32},
-    {"mtb4fap_mmaJ33", "eobrd_port_mtb4fap_mmaJ33", eobrd_port_mtb4fap_mmaJ33, eobrd_mtb4fap, eobrd_conn_J33},
     
     {"mtb4_mmaJ30", "eobrd_port_mtb4_mmaJ30", eobrd_port_mtb4_mmaJ30, eobrd_mtb4, eobrd_conn_J30},
     {"mtb4_mmaJ31", "eobrd_port_mtb4_mmaJ31", eobrd_port_mtb4_mmaJ31, eobrd_mtb4, eobrd_conn_J31},

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -77,14 +77,13 @@ typedef enum
     eobrd_cantype_pmc               = ICUBCANPROTO_BOARDTYPE__PMC,      // 17 (pmc = piezo motor control)
     eobrd_cantype_amcbldc           = ICUBCANPROTO_BOARDTYPE__AMCBLDC,  // 18 (amcbldc)
     eobrd_cantype_bms               = ICUBCANPROTO_BOARDTYPE__BMS,      // 19 (bms)
-    eobrd_cantype_mtb4c             = ICUBCANPROTO_BOARDTYPE__MTB4C,    // 20 (mtb4c)  
-    eobrd_cantype_mtb4fap           = ICUBCANPROTO_BOARDTYPE__MTB4FAP,  // 21 (mtb4fap)     
+    eobrd_cantype_mtb4c             = ICUBCANPROTO_BOARDTYPE__MTB4C,    // 20 (mtb4c)     
     eobrd_cantype_strain2c          = ICUBCANPROTO_BOARDTYPE__STRAIN2C, // 22 (strain2c)     
     eobrd_cantype_none              = 254, 	
     eobrd_cantype_unknown           = ICUBCANPROTO_BOARDTYPE__UNKNOWN   // 255 
 } eObrd_cantype_t;
 
-enum { eobrd_cantype_numberof = 22 };
+enum { eobrd_cantype_numberof = 21 };
 
 
 typedef enum
@@ -134,14 +133,13 @@ typedef enum
     eobrd_amcbldc               = eobrd_cantype_amcbldc,
     eobrd_bms                   = eobrd_cantype_bms,
     eobrd_mtb4c                 = eobrd_cantype_mtb4c,
-    eobrd_mtb4fap               = eobrd_cantype_mtb4fap,
     eobrd_strain2c              = eobrd_cantype_strain2c,
 
     eobrd_none                  = 254,                      
     eobrd_unknown               = 255  // = ICUBCANPROTO_BOARDTYPE__UNKNOWN                     
 } eObrd_type_t;
 
-enum { eobrd_type_numberof = 27 };
+enum { eobrd_type_numberof = 26 };
 
 
 typedef struct                  
@@ -353,11 +351,6 @@ typedef enum
     eobrd_port_amc_J5_X2            = 1,        // SPI encoder: embot::hw::encoder2
     eobrd_port_amc_J5_X3            = 2,        // SPI encoder: embot::hw::encoder3
 
-    eobrd_port_mtb4fap_J3_SDA0      = 0,
-    eobrd_port_mtb4fap_J3_SDA1      = 1,
-    eobrd_port_mtb4fap_J3_SDA2      = 2,
-    eobrd_port_mtb4fap_J3_SDA3      = 3,  
-
     eobrd_port_mtb4_J3_SDA0         = 0,
     eobrd_port_mtb4_J3_SDA1         = 1,
     eobrd_port_mtb4_J3_SDA2         = 2,
@@ -372,11 +365,6 @@ typedef enum
     eobrd_port_pmc_J5               = 1,        // I2C2
     eobrd_port_pmc_J6               = 2,        // I2C3
     eobrd_port_pmc_J7               = 3,        // I2C4 
-
-    eobrd_port_mtb4fap_mmaJ20       = 0,
-    eobrd_port_mtb4fap_mmaJ21       = 1,
-    eobrd_port_mtb4fap_mmaJ22       = 2,
-    eobrd_port_mtb4fap_mmaJ23       = 3,   
     
     eobrd_port_mtb4_mmaJ20          = 0,
     eobrd_port_mtb4_mmaJ21          = 1,
@@ -386,12 +374,7 @@ typedef enum
     eobrd_port_mtb4c_mmaJ20         = 0,
     eobrd_port_mtb4c_mmaJ21         = 1,
     eobrd_port_mtb4c_mmaJ22         = 2,
-    eobrd_port_mtb4c_mmaJ23         = 3,
-
-    eobrd_port_mtb4fap_mmaJ30       = 0,
-    eobrd_port_mtb4fap_mmaJ31       = 1,
-    eobrd_port_mtb4fap_mmaJ32       = 2,
-    eobrd_port_mtb4fap_mmaJ33       = 3,   
+    eobrd_port_mtb4c_mmaJ23         = 3, 
     
     eobrd_port_mtb4_mmaJ30          = 0,
     eobrd_port_mtb4_mmaJ31          = 1,
@@ -403,10 +386,9 @@ typedef enum
     eobrd_port_mtb4c_mmaJ32         = 2,
     eobrd_port_mtb4c_mmaJ33         = 3
        
-    
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 59 };
+enum { eobrd_ports_numberof = 47 };
 
 
 typedef enum


### PR DESCRIPTION
This PR is associated w/ others (see below) which remove the board `mtb4fap` from `robotology` because its functionalities are offered by the `mtb4c`.

Associated PRs:
- tbd
- tbd
- tbd