### PR TITLE
Added calibration 14 data struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.34.0)
+        VERSION 1.34.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -218,6 +218,7 @@ typedef enum
     eomc_calibration_type11_cer_hands               = 11,   // cannot change
     eomc_calibration_type12_absolute_sensor         = 12,   // cannot change  //substitutes type 3
     eomc_calibration_type13_cer_hands_2             = 13,   // cannot change
+    eomc_calibration_type14_qenc_hard_stop_and_fap  = 14,   // cannot change
     eomc_calibration_typeMixed                      = 254,  // cannot change 
     eomc_calibration_typeUndefined                  = 255   // cannot change
 } eOmc_calibration_type_t;
@@ -441,6 +442,26 @@ typedef struct
     int32_t                     rawValueAtZeroPos3;
 } eOmc_calibrator_params_type13_cer_hands_2_t;
 
+
+/** @typedef    typedef struct eOmc_calibrator_params_type14_qenc_hard_stop_and_fap_t 
+    @brief      contains the params in case of eomc_calibration_type14_qenc_hard_stop_and_fap_t
+ **/
+typedef struct  
+{
+    int32_t                     pwmlimit;
+    int32_t                     final_pos;
+    uint8_t                     invertdirection;
+    uint8_t                     rotation;
+    uint8_t                     filler;
+    int32_t                     offset;
+    int32_t                     calibrationZero;
+    
+} eOmc_calibrator_params_type14_qenc_hard_stop_and_fap_t;
+
+
+
+
+
 // -- all the possible data holding structures used in a joint
 
 
@@ -551,6 +572,7 @@ typedef struct                  // size is 1+3+4*4 = 20
         eOmc_calibrator_params_type11_cer_hands_t                   type11; 
         eOmc_calibrator_params_type12_absolute_sensor_t             type12;
         eOmc_calibrator_params_type13_cer_hands_2_t                 type13;
+        eOmc_calibrator_params_type14_qenc_hard_stop_and_fap_t      type14;
     } params;                                                       /**< the params of the calibrator */   
 } eOmc_calibrator32_t;           EO_VERIFYsizeof(eOmc_calibrator32_t, 28)
 


### PR DESCRIPTION
In this PR we added the data related to calibration 14: it is used for the open close joint f ergoCub fingers.

### **Important note**
Even if the calibration 14 parameters hosts both motor encoder info and joint encoder (`FAP`)info,  currently only the data regarding the motor encoder are used: `pwmlimit` and `final_pos.` 

----------------

### Related PRs:
 - [fw PR](https://github.com/robotology/icub-firmware/pull/363)
 - [icub-main PR](https://github.com/robotology/icub-main/pull/862)




cc @MSECode  