### PR TITLE
Added the `mrie` encoder. Increase version to ` 1.34.2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.34.1)
+        VERSION 1.34.2)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -95,6 +95,7 @@ static const eOmap_str_str_u08_t s_eomc_map_of_encoders[] =
     {"amo", "eomc_enc_amo", eomc_enc_amo},
     {"psc", "eomc_enc_psc", eomc_enc_psc},
     {"pos", "eomc_enc_pos", eomc_enc_pos},
+    {"mrie", "eomc_enc_mrie", eomc_enc_mrie},
 
     {"none", "eomc_enc_none", eomc_enc_none},
     {"unknown", "eomc_enc_unknown", eomc_enc_unknown}
@@ -277,6 +278,7 @@ extern uint8_t eomc_encoder_get_numberofcomponents(eOmc_encoder_t encoder)
         case eomc_enc_hallmotor: 
         case eomc_enc_amo:
         case eomc_enc_aksim2:
+        case eomc_enc_mrie:
         {
             ret = 1;
         } break;

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -1141,12 +1141,13 @@ typedef enum
     eomc_enc_pos            = 11,
     eomc_enc_aea3           = 12,
     eomc_enc_aksim2         = 13,
+    eomc_enc_mrie           = 14,
     
     eomc_enc_none           = 0,
     eomc_enc_unknown        = 255    
 } eOmc_encoder_t;
 
-enum { eomc_encoders_numberof = 13 };
+enum { eomc_encoders_numberof = 14 };
 enum { eomc_encoders_maxnumberofcomponents = 4 };
 
 


### PR DESCRIPTION
In this PR I added the `mrie` encoder type.
I updated the version to 1.34.2.

Even if this change doesn't affect the firmware, I'm going to compile all FWs and open a PR.

This PR is related with this [one](https://github.com/robotology/icub-main/pull/869) of icub-main.