### PR TITLE
Calibration type 14 update and refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.34.2)
+        VERSION 1.34.3)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/core/core/EoCommon.h
+++ b/eth/embobj/core/core/EoCommon.h
@@ -596,6 +596,14 @@ typedef struct
     uint8_t         val2;    
 } eOmap_str_str_u08_u08_u08_t;
 
+/** @typedef    typedef struct eOmap_int32_u08_t
+    @brief      it can be used to build a map containing one int32_t and a value. 
+ **/
+typedef struct
+{
+    int32_t         int0;
+    uint8_t         val0;    
+} eOmap_int32_u08_t;
 
 // - public #define  --------------------------------------------------------------------------------------------------
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.c
@@ -114,7 +114,7 @@ static const eOmap_str_str_u08_t s_boards_map_of_posrots[] =
     {"minus090", "eoas_pos_ROT_minus090", eoas_pos_ROT_minus090},
     
     {"none", "eoas_pos_ROT_none", eoas_pos_ROT_none},
-    {"unknown", "eoas_pos_ROT_unknown", eoas_pos_ROT_unknown}   
+    {"unknown", "eoas_pos_ROT_unknown", eoas_pos_ROT_unknown}
     
 };  EO_VERIFYsizeof(s_boards_map_of_posrots, (eoas_pos_ROT_numberof+2)*sizeof(eOmap_str_str_u08_t))
 
@@ -609,7 +609,7 @@ extern eObool_t eoas_battery_isboardvalid(eObrd_cantype_t boardtype)
         }
     }
     
-    return eobool_false;    
+    return eobool_false;
 }
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -173,6 +173,18 @@ static const eOmap_str_str_u08_t s_eomc_map_of_jsetconstraints[] =
     {"unknown", "eomc_jsetconstraint_unknown", eomc_jsetconstraint_unknown}
 };  EO_VERIFYsizeof(s_eomc_map_of_jsetconstraints, (eomc_jsetconstraints_numberof + 1)*sizeof(eOmap_str_str_u08_t));
 
+static const eOmap_int32_u08_t s_eomc_map_of_calib14rot[] =
+{
+    {0, eOmc_calib14_ROT_zero},
+    {32768, eOmc_calib14_ROT_plus180},
+    {16384, eOmc_calib14_ROT_plus090},
+    {-16384, eOmc_calib14_ROT_minus090},
+    
+    {-1, eOmc_calib14_ROT_none},
+    {-2, eOmc_calib14_ROT_unknown}   
+    
+};  EO_VERIFYsizeof(s_eomc_map_of_calib14rot, (eOmc_calib14_ROT_numberof+2)*sizeof(eOmap_int32_u08_t))
+
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables
@@ -433,6 +445,40 @@ extern eOmc_stopswitch_t eomc_stopswitch_getlow(const eomc_stopswitches_t value)
 extern eOmc_stopswitch_t eomc_stopswitch_gethigh(const eomc_stopswitches_t value)
 {
     return (eOmc_stopswitch_t)((value >> 4) & 0xf);
+}
+
+extern eOmc_calib14_ROT_t eomc_int2calib14_ROT(int32_t value)
+{
+    uint8_t i = 0;
+    const eOmap_int32_u08_t *map = s_eomc_map_of_calib14rot;
+    const uint8_t size = eOmc_calib14_ROT_numberof+2;
+    uint8_t defvalue = eOmc_calib14_ROT_unknown;
+    
+    for(i = 0; i < size; i++)
+    {
+        if(map[i].int0 == value)
+        {
+            return(map[i].val0);
+        }
+    }
+    return defvalue;
+}
+
+extern int32_t eomc_calib14_ROT2int(eOmc_calib14_ROT_t value)
+{
+    uint8_t i = 0;
+    const eOmap_int32_u08_t *map = s_eomc_map_of_calib14rot;
+    const uint8_t size = eOmc_calib14_ROT_numberof+2;
+    uint8_t defvalue = -2;
+    
+    for(i = 0; i < size; i++)
+    {
+        if(map[i].val0 == value)
+        {
+            return(map[i].int0);
+        }
+    }
+    return defvalue;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -451,8 +451,9 @@ typedef struct
     int32_t                     pwmlimit;
     int32_t                     final_pos;
     uint8_t                     invertdirection;
-    uint8_t                     rotation;
-    uint8_t                     filler;
+    uint8_t                     filler8;
+    uint16_t                    filler16;
+    int32_t                     rotation;
     int32_t                     offset;
     int32_t                     calibrationZero;
     
@@ -551,7 +552,7 @@ typedef struct                  // size is 1+1+2+2+2+0 = 8
 /** @typedef    typedef struct eOmc_calibrator32_t
     @brief      eOmc_calibrator32_t specifies a calibrator with type and parameters for teh new definition of measures
  **/
-typedef struct                  // size is 1+3+4*4 = 20
+typedef struct                  // size is 1+3+6*4 = 28
 {
     eOenum08_t                  type;                               /**< use eOmc_calibration_type_t */
     uint8_t                     filler03[3];
@@ -1426,6 +1427,18 @@ typedef enum
 
 enum { eomc_mc4broadcasts_numberof = 5 };
 
+typedef enum
+{
+    eOmc_calib14_ROT_zero = 0,
+    eOmc_calib14_ROT_plus180 = 1,
+    eOmc_calib14_ROT_plus090 = 2,
+    eOmc_calib14_ROT_minus090 = 3,
+    eOmc_calib14_ROT_none = 14,
+    eOmc_calib14_ROT_unknown = 15,
+} eOmc_calib14_ROT_t;
+
+enum { eOmc_calib14_ROT_numberof = 4 };
+
 
 
 // - declaration of extern public variables, ... but better using use _get/_set instead -------------------------------
@@ -1463,6 +1476,8 @@ extern eOmc_pidoutputtype_t eomc_string2pidoutputtype(const char * string, eOboo
 extern eOmc_jsetconstraint_t eomc_string2jsetconstraint(const char * string, eObool_t usecompactstring);
 extern const char * eomc_jsetconstraint2string(eOmc_jsetconstraint_t jsetconstraint, eObool_t usecompactstring);
 
+extern eOmc_calib14_ROT_t eomc_int2calib14_ROT(int32_t value);
+extern int32_t eomc_calib14_ROT2int(eOmc_calib14_ROT_t value);
 
 /** @}            
     end of group eo_motioncontrol  


### PR DESCRIPTION
Update POS service and correlated methods for new calibration type 14 improvement

Specifically, important changes to check are the following:
- addition of the `typedef struct eOmap_int32_u08_t` used to map rotation values in `int32_t` with the ones in `uint8_t` used by the enum defined in the POS service
- definition of the `static array s_eomc_map_of_calib14rot` used for keeping the available values accepted for the rotation parameter
- definition of the method `eomc_int2calib14_ROT` used for performing the conversion from int32_t and uint8_t specific data type and inverse method `eomc_calib14_ROT2int` to convert a value of type `eOmc_calib14_ROT_t` to `int32_t`
- fix values of struct `eOmc_calibrator_params_type14_qenc_hard_stop_and_fap_t` by setting data type `int32_t` for rotation which is not treated as `uint8_t` by that struct and then re-defined the filler bits for keeping standard ordered groups of data of 32bit each
- improve version defined in `CMakeLists.txt` to `1.34.3`

