### PR TITLE
Update EoMotionControl to support the new velocityThres parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.37.0)
+        VERSION 1.37.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -643,11 +643,13 @@ typedef struct              // size is 1+3+8+0 = 12
 
 typedef struct
 {
+    float                   bemf_value;
     float                   ktau_value;
     eOmc_FrictionParams_t   friction;
+    int8_t                  bemf_scale;
     int8_t                  ktau_scale;
-    int8_t                  filler02[3];
-} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 28)
+    int8_t                  filler02[2];
+} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 32)
 
 // -- all the possible data holding structures used in a motor
 
@@ -712,7 +714,7 @@ typedef struct                  // size is: 40+40+40+8+8+12+4+4+28+2+1+1+4+4+4+3
     float32_t                   gearbox_E2J;
     float32_t                   deadzone;
     eOmc_kalman_filter_config_t kalman_params;              /**< the kalman filter parameters */
-} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 236)
+} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 240)
 
 
 /** @typedef    typedef struct eOmc_status_ofpid_legacy_t
@@ -915,7 +917,7 @@ typedef struct                  // size is 236+96+4+44+0 = 380
     eOmc_joint_status_t         status;                     /**< the status of the joint */
     eOmc_joint_inputs_t         inputs;                     /**< it contains all the values that a host can send to a joint as inputs */
     eOmc_joint_commands_t       cmmnds;                     /**< it contains all the commands that a host can send to a joint */
-} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 380);
+} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 384);
 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -494,7 +494,8 @@ typedef struct
     float32_t               viscous_neg_val;
     float32_t               coulomb_pos_val;
     float32_t               coulomb_neg_val;
-} eOmc_FrictionParams_t;    EO_VERIFYsizeof(eOmc_FrictionParams_t, 16)
+    float32_t               velocityThres_val;
+} eOmc_FrictionParams_t;    EO_VERIFYsizeof(eOmc_FrictionParams_t, 20)
 
 typedef struct
 {
@@ -648,7 +649,7 @@ typedef struct
     int8_t                  bemf_scale;
     int8_t                  ktau_scale;
     int8_t                  filler02[2];
-} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 28)
+} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 32)
 
 // -- all the possible data holding structures used in a motor
 
@@ -713,7 +714,7 @@ typedef struct                  // size is: 40+40+40+8+8+12+4+4+28+2+1+1+4+4+4+3
     float32_t                   gearbox_E2J;
     float32_t                   deadzone;
     eOmc_kalman_filter_config_t kalman_params;              /**< the kalman filter parameters */
-} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 236)
+} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 240)
 
 
 /** @typedef    typedef struct eOmc_status_ofpid_legacy_t
@@ -916,7 +917,7 @@ typedef struct                  // size is 236+96+4+44+0 = 380
     eOmc_joint_status_t         status;                     /**< the status of the joint */
     eOmc_joint_inputs_t         inputs;                     /**< it contains all the values that a host can send to a joint as inputs */
     eOmc_joint_commands_t       cmmnds;                     /**< it contains all the commands that a host can send to a joint */
-} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 380);
+} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 384);
 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -643,13 +643,11 @@ typedef struct              // size is 1+3+8+0 = 12
 
 typedef struct
 {
-    float                   bemf_value;
     float                   ktau_value;
     eOmc_FrictionParams_t   friction;
-    int8_t                  bemf_scale;
     int8_t                  ktau_scale;
-    int8_t                  filler02[2];
-} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 32)
+    int8_t                  filler02[3];
+} eOmc_motor_params_t;  EO_VERIFYsizeof(eOmc_motor_params_t, 28)
 
 // -- all the possible data holding structures used in a motor
 
@@ -714,7 +712,7 @@ typedef struct                  // size is: 40+40+40+8+8+12+4+4+28+2+1+1+4+4+4+3
     float32_t                   gearbox_E2J;
     float32_t                   deadzone;
     eOmc_kalman_filter_config_t kalman_params;              /**< the kalman filter parameters */
-} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 240)
+} eOmc_joint_config_t;          EO_VERIFYsizeof(eOmc_joint_config_t, 236)
 
 
 /** @typedef    typedef struct eOmc_status_ofpid_legacy_t
@@ -917,7 +915,7 @@ typedef struct                  // size is 236+96+4+44+0 = 380
     eOmc_joint_status_t         status;                     /**< the status of the joint */
     eOmc_joint_inputs_t         inputs;                     /**< it contains all the values that a host can send to a joint as inputs */
     eOmc_joint_commands_t       cmmnds;                     /**< it contains all the commands that a host can send to a joint */
-} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 384);
+} eOmc_joint_t;                 EO_VERIFYsizeof(eOmc_joint_t, 380);
 
 
 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMC.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 25 };
+enum { eoprot_version_mc_major = 1, eoprot_version_mc_minor = 26 };
 
 enum { eoprot_entities_mc_numberof = eomc_entities_numberof };
 


### PR DESCRIPTION
**What's new:**
- the `eOmc_motor_params_t` structure has been extended with the new `velocityThres`
~~- the `bemf_value` and `bemf_scale` params have been removed from the `eOmc_motor_params_t` as they will not be used~~

> **Note**
> - tested on a single joint setup
