### PR TITLE
Add new eOas_batterymode_t enum for CAN TX modes

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -111,6 +111,12 @@ enum { eoas_entities_numberof = 8 };
 
 typedef enum
 {
+    eoas_batterymode_txdatacontinuously                    = 0,
+    eoas_batterymode_acquirebutdonttx                      = 1,
+} eOas_batterymode_t;
+
+typedef enum
+{
     eoas_strainmode_txcalibrateddatacontinuously        = 0,
     eoas_strainmode_acquirebutdonttx                    = 1,
     eoas_strainmode_txuncalibrateddatacontinuously      = 3,


### PR DESCRIPTION
This PR is related to:

https://github.com/robotology/icub-firmware/pull/447