### PR TITLE
Move MotorFaultState to EoMotionControl

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -56,6 +56,57 @@ extern "C" {
 
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
+typedef union
+{
+    struct
+    {
+        //B0 L
+        unsigned ExternalFaultAsserted  :1;
+        unsigned UnderVoltageFailure    :1;      
+        unsigned OverVoltageFailure     :1;
+        unsigned OverCurrentFailure     :1;
+        //B0 H
+        unsigned DHESInvalidValue       :1;
+        unsigned AS5045CSumError        :1;
+        unsigned DHESInvalidSequence    :1;
+        unsigned CANInvalidProtocol     :1;
+        //B1 L
+        unsigned CAN_BufferOverRun      :1;
+        unsigned SetpointExpired        :1;
+        unsigned CAN_TXIsPasv           :1;
+        unsigned CAN_RXIsPasv           :1;
+        //B1 H
+        unsigned CAN_IsWarnTX           :1;
+        unsigned CAN_IsWarnRX           :1;
+        unsigned OverHeatingFailure     :1;
+        unsigned unused                 :1;
+        //B2 L
+        unsigned ADCCalFailure          :1; 
+        unsigned I2TFailure             :1;                     
+        unsigned EMUROMFault            :1;
+        unsigned EMUROMCRCFault         :1;
+        //B2 H
+        unsigned EncoderFault           :1;
+        unsigned FirmwareSPITimingError :1;		
+        unsigned AS5045CalcError        :1;
+        unsigned FirmwarePWMFatalError  :1;
+        //B3 L
+        unsigned CAN_TXWasPasv          :1;
+        unsigned CAN_RXWasPasv          :1;
+        unsigned CAN_RTRFlagActive      :1;
+        unsigned CAN_WasWarn            :1;
+        //B3 H
+        unsigned CAN_DLCError           :1;
+        unsigned SiliconRevisionFault   :1;
+        unsigned PositionLimitUpper     :1; 
+        unsigned PositionLimitLower     :1; 
+    } bits;
+        
+    uint32_t bitmask;
+        
+} eOmc_motorFaultState_t;
+
+enum {eOmc_motorFaultState_numberof = 32};
 
 /** @typedef    typedef enum eOmc_entity_t;
     @brief      It contains all the possible entities managed by motion control.


### PR DESCRIPTION
Move MotorFaultState to EoMotionControl in order that we can use same type on both fw and sw.
Then add the enum typedef as guard
Change type mc_fault_state for being compliant with all definitions done in fw and sw


Related to: 
https://github.com/robotology/icub-firmware/pull/472
https://github.com/robotology/icub-main/pull/942