### PR TITLE
Update CMakeLists.txt with icub_firmware_shared version to 1.38.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(icub_firmware_shared
-        VERSION 1.38.1)
+        VERSION 1.38.2)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
+++ b/eth/embobj/plus/comm-v2/icub/EoAnalogSensors.h
@@ -731,13 +731,13 @@ typedef enum
     //thus to give to bms a certain amount of int for the statuses thinking about a future expantion 
     // so that number from 0 to 15 are restricted to bms and the other to bat
     //an then add null values in the map for the empty spaces
-    eoas_bms_general_alarm_lowvoltage            = 1,
-    eoas_bms_general_alarm_highvoltage           = 2,
-    eoas_bms_general_alarm_overcurrent_discharge = 3,
-    eoas_bms_general_alarm_overcurrent_charge    = 4,
-    eoas_bms_general_alarm_lowSOC                = 5,
-    eoas_bms_general_alarm_lowtemperature        = 6,
-    eoas_bms_general_alarm_hightemperature       = 7,
+    eoas_bms_general_alarm_lowvoltage            = 0,
+    eoas_bms_general_alarm_highvoltage           = 1,
+    eoas_bms_general_alarm_overcurrent_discharge = 2,
+    eoas_bms_general_alarm_overcurrent_charge    = 3,
+    eoas_bms_general_alarm_lowSOC                = 4,
+    eoas_bms_general_alarm_lowtemperature        = 5,
+    eoas_bms_general_alarm_hightemperature       = 6,
     eoas_bat_status_hsm_mosfet_broken            = 16, 
     eoas_bat_status_hsm_mosfet_normal            = 116, //(x-1)+100
     eoas_bat_status_hsm_overcurrent_overvoltage  = 17,
@@ -759,7 +759,7 @@ typedef enum
     eoas_bat_status_btn_1_start_up_phase         = 25,
     eoas_bat_status_btn_1_stable_op              = 125
 } eOas_battery_alarm_status_t;
-enum { eoas_bms_alarm_numberof = 8, eoas_battery_alarm_status_numberof = 27 };
+enum { eoas_bms_alarm_numberof = 7, eoas_battery_alarm_status_numberof = 27 };
 
 
 typedef struct
@@ -780,7 +780,7 @@ typedef struct
     eOabstime_t             age;               // timeoflife in usec. better using this because yarp may ask the board to have its time
     int16_t                 temperature;       // in steps of 0.1 celsius degree (pos and neg).
     int16_t                 filler16;          // filler to cover the remaining 16bits considired that we are working efficiently in memory packs of 32bits
-    uint32_t                status;            // status used on both BAT(10 bits - primary in 0x00000000ffffffff - secondary in 0x000000ff00000000) and BMS(8 MSB)
+    uint16_t                status;            // status used on both BAT(10 bits - primary in 0x00000000ffffffff - secondary in 0x000000ff00000000) and BMS(8 MSB) --> does not make sense since they are intialized as separated instances
     float32_t               voltage;  
     float32_t               current;  
     float32_t               charge; 

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolAS.h
@@ -57,7 +57,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 10 };
+enum { eoprot_version_as_major = 1, eoprot_version_as_minor = 11 };
 
 
 enum { eoprot_entities_as_numberof = eoas_entities_numberof };


### PR DESCRIPTION
Changes of this PR:
- Reset status variable in struct `eOas_battery_timedvalue_t` datatype to uint16_t
- Correct the enum values and max dimension enum definitions of eOas_battery_alarm_status_t
- Update version to 1.38.2

Related to: 
- https://github.com/robotology/icub-firmware/pull/487
- https://github.com/robotology/icub-main/pull/953
- https://github.com/robotology/icub-firmware-build/pull/146