### PR TITLE
Bump C++ version used in embot to C++17

### DIFF
--- a/embot/CMakeLists.txt
+++ b/embot/CMakeLists.txt
@@ -43,7 +43,7 @@ if(WITH_EMBOT)
   set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION  ${${PROJECT_NAME}_VERSION}
                                                           PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
 
-  target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_14)
+  target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_17)
   install(TARGETS ${LIBRARY_TARGET_NAME}
           EXPORT ${PROJECT_NAME}
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
https://github.com/robotology/icub-firmware-shared/pull/97 added a nested namespace (https://en.cppreference.com/w/cpp/language/namespace) to embot headers, that is a feature available only in C++17 . Recent versions of gcc and clang default to use C++17 so this is not a problem, while trying to compile the file in Visual Studio results in an error:

~~~
2024-10-01T03:15:18.9723412Z D:\a\robotology-superbuild\robotology-superbuild\src\icub_firmware_shared\embot\core\embot_core_binary.h(288,11): error C2429: language feature 'nested-namespace-definition' requires compiler flag '/std:c++17' [D:\a\robotology-superbuild\robotology-superbuild\b\src\icub_firmware_shared\embot\embot.vcxproj] [D:\a\robotology-superbuild\robotology-superbuild\b\icub_firmware_shared.vcxproj]
~~~

see https://github.com/robotology/robotology-superbuild/actions/runs/11117493180/job/30889518253 .

This PR fixes the compilation error by bumping the C++ standard version used from C++14 to C++17 .