### PR TITLE
Realigned types for skin type ERGOHAND

### DIFF
--- a/can/canProtocolLib/iCubCanProto_types.h
+++ b/can/canProtocolLib/iCubCanProto_types.h
@@ -84,9 +84,12 @@ extern "C" {
 #define ICUBCANPROTO_BOARDTYPE__UNKNOWN  255
 
 // skin types
-#define ICUBCANPROTO_SKINTYPE__WITHTEMPCOMP    0  
-#define ICUBCANPROTO_SKINTYPE__PALMFINGERTIP   1    
-#define ICUBCANPROTO_SKINTYPE__WITHOUTTEMPCOMP 2    
+#define ICUBCANPROTO_SKINTYPE__WITHTEMPCOMP     0  
+#define ICUBCANPROTO_SKINTYPE__PALMFINGERTIP    1    
+#define ICUBCANPROTO_SKINTYPE__WITHOUTTEMPCOMP  2 
+#define ICUBCANPROTO_SKINTYPE__ERGOHAND         3
+#define ICUBCANPROTO_SKINTYPE__TESTMODERAW      7
+#define ICUBCANPROTO_SKINTYPE__WITHTEMPCOMPV2   8
 
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
@@ -472,7 +475,10 @@ typedef enum
 {
     icubCanProto_skinType__withtempcomp       = ICUBCANPROTO_SKINTYPE__WITHTEMPCOMP,
     icubCanProto_skinType__palmfingertip      = ICUBCANPROTO_SKINTYPE__PALMFINGERTIP,
-    icubCanProto_skinType__withouttempcomp    = ICUBCANPROTO_SKINTYPE__WITHOUTTEMPCOMP
+    icubCanProto_skinType__withouttempcomp    = ICUBCANPROTO_SKINTYPE__WITHOUTTEMPCOMP,
+    icubCanProto_skinType__ergohand           = ICUBCANPROTO_SKINTYPE__ERGOHAND,
+    icubCanProto_skinType__testmoderaw        = ICUBCANPROTO_SKINTYPE__TESTMODERAW,
+    icubCanProto_skinType__withtempcompv2     = ICUBCANPROTO_SKINTYPE__WITHTEMPCOMPV2    
 } icubCanProto_skinType_t;
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoSkin.h
+++ b/eth/embobj/plus/comm-v2/icub/EoSkin.h
@@ -82,7 +82,10 @@ typedef enum
 {   // they must be equal to what the can protocol specifies
     eosk_skintype_withtempcomp                      = icubCanProto_skinType__withtempcomp,      /**< 0 */  
     eosk_skintype_palmfingertip                     = icubCanProto_skinType__palmfingertip,     /**< 1 */
-    eosk_skintype_withouttempcomp                   = icubCanProto_skinType__withouttempcomp    /**< 2 */   
+    eosk_skintype_withouttempcomp                   = icubCanProto_skinType__withouttempcomp,   /**< 2 */   
+    eosk_skintype_ergohand                          = icubCanProto_skinType__ergohand,          /**< 3 */  
+    eosk_skintype_testmoderaw                       = icubCanProto_skinType__testmoderaw,       /**< 7 */
+    eosk_skintype_withtempcompv2                    = icubCanProto_skinType__withtempcompv2     /**< 8 */       
 } eOsk_skintype_t;
 
 // -- all the possible data service structures


### PR DESCRIPTION
This PR just adds some macros and values for the skin type of `ergoCub` hand discussed in this PR:
- https://github.com/robotology/icub-firmware/pull/530

It can be merged w/out any harm.

