### PR TITLE
`amcfoc` connectors and ports

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoBoards.c
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.c
@@ -97,7 +97,8 @@ static const uint64_t s_eoboards_is_can_mask =  (0x1LL << eobrd_mc4) |
                                                 (0x1LL << eobrd_mtb4c) |
                                                 (0x1LL << eobrd_amc2c)|
                                                 (0x1LL << eobrd_strain2c) | 
-                                                (0x1LL << eobrd_bat);
+                                                (0x1LL << eobrd_bat) |
+                                                (0x1LL << eobrd_amcfoc2c); 
        
    
 static const eOmap_str_str_u08_t s_eoboards_map_of_boards[] =
@@ -186,6 +187,9 @@ static const eOmap_str_str_u08_t s_eoboards_map_of_connectors[] =
     {"P3P", "eobrd_conn_P3P", eobrd_conn_P3P},
     {"P4P", "eobrd_conn_P4P", eobrd_conn_P4P},
 
+    {"J11", "eobrd_conn_J11", eobrd_conn_J11},
+    {"J12", "eobrd_conn_J12", eobrd_conn_J12},
+
     {"none", "eobrd_conn_none", eobrd_conn_none},
     {"unknown", "eobrd_conn_unknown", eobrd_conn_unknown}
 };  EO_VERIFYsizeof(s_eoboards_map_of_connectors, (eobrd_connectors_numberof+2)*sizeof(eOmap_str_str_u08_t))
@@ -252,6 +256,9 @@ static const eOmap_str_str_u08_u08_u08_t s_eoboards_map_of_ports[] =
     {"mtb4c_mmaJ31", "eobrd_port_mtb4c_mmaJ31", eobrd_port_mtb4c_mmaJ31, eobrd_mtb4c, eobrd_conn_J31},
     {"mtb4c_mmaJ32", "eobrd_port_mtb4c_mmaJ32", eobrd_port_mtb4c_mmaJ32, eobrd_mtb4c, eobrd_conn_J32},
     {"mtb4c_mmaJ33", "eobrd_port_mtb4c_mmaJ33", eobrd_port_mtb4c_mmaJ33, eobrd_mtb4c, eobrd_conn_J33},
+
+    {"amcfocJ11", "eobrd_port_amcfoc_J11", eobrd_port_amcfoc_J11, eobrd_amcfoc, eobrd_conn_J11},
+    {"amcfocJ12", "eobrd_port_amcfoc_J12", eobrd_port_amcfoc_J12, eobrd_amcfoc, eobrd_conn_J12},
     
     {"none", "eobrd_port_none", eobrd_port_none, eobrd_none, eobrd_conn_none},
     {"unknown", "eobrd_port_unknown", eobrd_port_unknown, eobrd_unknown, eobrd_conn_unknown}

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -82,6 +82,7 @@ typedef enum
     eobrd_cantype_strain2c          = ICUBCANPROTO_BOARDTYPE__STRAIN2C, // 22 (strain2c)
     eobrd_cantype_bat               = ICUBCANPROTO_BOARDTYPE__BAT,      // 23 (bat)
     eobrd_cantype_amcfoc2c          = ICUBCANPROTO_BOARDTYPE__AMCFOC2C, // 24 (amcfoc2c)
+
     eobrd_cantype_none              = 254, 	
     eobrd_cantype_unknown           = ICUBCANPROTO_BOARDTYPE__UNKNOWN   // 255 
 } eObrd_cantype_t;
@@ -325,12 +326,14 @@ typedef enum
     eobrd_conn_J33      = 34,
     eobrd_conn_P3P      = 35,
     eobrd_conn_P4P      = 36,
+    eobrd_conn_J11      = 37,    
+    eobrd_conn_J12      = 38,
     
     eobrd_conn_none     = 0,
     eobrd_conn_unknown  = 255
 } eObrd_connector_t;
 
-enum { eobrd_connectors_numberof = 36 };
+enum { eobrd_connectors_numberof = 38 };
 
 
 typedef enum
@@ -397,11 +400,14 @@ typedef enum
     eobrd_port_mtb4c_mmaJ30         = 0,
     eobrd_port_mtb4c_mmaJ31         = 1,
     eobrd_port_mtb4c_mmaJ32         = 2,
-    eobrd_port_mtb4c_mmaJ33         = 3
+    eobrd_port_mtb4c_mmaJ33         = 3,
+
+    eobrd_port_amcfoc_J11            = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amcfoc_J12            = 1,        // SPI encoder: embot::hw::encoder2
        
 } eObrd_port_t;
 
-enum { eobrd_ports_numberof = 49 };
+enum { eobrd_ports_numberof = 51 };
 
 
 typedef enum

--- a/eth/embobj/plus/comm-v2/icub/EoBoards.h
+++ b/eth/embobj/plus/comm-v2/icub/EoBoards.h
@@ -402,8 +402,8 @@ typedef enum
     eobrd_port_mtb4c_mmaJ32         = 2,
     eobrd_port_mtb4c_mmaJ33         = 3,
 
-    eobrd_port_amcfoc_J11            = 0,        // SPI encoder: embot::hw::encoder1
-    eobrd_port_amcfoc_J12            = 1,        // SPI encoder: embot::hw::encoder2
+    eobrd_port_amcfoc_J11           = 0,        // SPI encoder: embot::hw::encoder1
+    eobrd_port_amcfoc_J12           = 1,        // SPI encoder: embot::hw::encoder2
        
 } eObrd_port_t;
 


### PR DESCRIPTION
Adding `amcfoc` connectors and ports and the board in the can mask.

Now the string  `J11` / `J12` in an xml file that asks to board `amcfoc` to run the MC service will be correctly parsed by `yarprobotinterface` and sent to the board as port 0 / 1 that is associated signals on the physical `J11` / `J12` connector.
