### PR TITLE
Update error messages for temperature and amo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(icub_firmware_shared VERSION 1.41.2)
+project(icub_firmware_shared VERSION 1.41.3)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -179,7 +179,9 @@ const eoerror_valuestring_t eoerror_valuestrings_HW[] =
     {eoerror_value_HW_encoder_invalid_value,   "HW - encoder: the position data is not valid", ""},
     {eoerror_value_HW_encoder_close_to_limits, "HW - encoder: the position data is valid, but some operating conditions are close to limits.", ""},
     {eoerror_value_HW_encoder_crc,             "HW - encoder: inverted CRC is invalid", ""},
-    {eoerror_value_HW_encoder_not_connected,   "HW - encoder: not connected"}
+    {eoerror_value_HW_encoder_not_connected,   "HW - encoder: not connected"},
+    {eoerror_value_HW_amo_encoder_status0,     "HW - amo encoder status0 error: poor-level or clipping in the signal of master and/or nonius track.", "In par64 counts for the number of errors in 10 seconds (lower: LS 32bits nonius_max|nonius_min, upper: MS 32bits master_max|master_min)"},
+    {eoerror_value_HW_amo_encoder_status1,     "HW - amo encoder status1 error: errors on reading on master and/or nonius track.", "In par64 counts for the number of errors in 10 seconds masked as: crc error 0xffff000000000000, i2c comm error 0x0000ffff00000000, nonius track period consistency error 0x00000000ffff0000, eccessive input signal frequency for converters error 0x000000000000ffff "}
 };  EO_VERIFYsizeof(eoerror_valuestrings_HW, eoerror_value_HW_numberof*sizeof(const eoerror_valuestring_t)) 
 
 
@@ -204,7 +206,8 @@ const eoerror_valuestring_t eoerror_valuestrings_MC[] =
     {eoerror_value_MC_motor_wrong_state,     "MC: 2FOC wrong state. The 2FOC motor controller is in a control state different from required by the EMS.", "In par64 0xF0 is the mask of requested state, 0x0F is the mask of actual state. par16 = ID of joint."},
     {eoerror_value_MC_joint_hard_limit,      "MC: hard limit reached. The joint position is outside its hardware boundaries.", "In par16 = ID of joint."},
     {eoerror_value_MC_motor_qencoder_phase_disappeared, "MC: qenc error has disappeared, warning counter has been reset.", ""},
-    {eoerror_value_MC_motor_overheating,     "MC: overheating. Temperature hardware limit exceeded. The motor has been turned off to prevent it from being damaged by overheating.", "In par16 = ID of the joint. In par64 0xFFFF is the mask of the raw tmperature feedback."}
+    {eoerror_value_MC_motor_overheating,     "MC: overheating. Temperature hardware limit exceeded. The motor has been turned off to prevent it from being damaged by overheating.", "In par16 = ID of the joint. In par64 0xFFFF is the mask of the raw tmperature feedback."},
+    {eoerror_value_MC_motor_tdb_not_reading, "MC: TDB cannot receive any data on I2C channel. Motor temperature detection board is not receiving any data on the i2C channel.", "In par16 = ID of the joint."}
 
 };  EO_VERIFYsizeof(eoerror_valuestrings_MC, eoerror_value_MC_numberof*sizeof(const eoerror_valuestring_t)) 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -198,10 +198,12 @@ typedef enum
     eoerror_value_HW_encoder_invalid_value   = 3,
     eoerror_value_HW_encoder_close_to_limits = 4,
     eoerror_value_HW_encoder_crc             = 5,
-    eoerror_value_HW_encoder_not_connected   = 6
+    eoerror_value_HW_encoder_not_connected   = 6,
+    eoerror_value_HW_amo_encoder_status0     = 7,
+    eoerror_value_HW_amo_encoder_status1     = 8
 } eOerror_value_HW_t;
 
-enum { eoerror_value_HW_numberof = 7 };
+enum { eoerror_value_HW_numberof = 9 };
 
 
 
@@ -234,10 +236,11 @@ typedef enum
     eoerror_value_MC_joint_hard_limit                   = 16,
     eoerror_value_MC_motor_qencoder_phase_disappeared   = 17,
     
-    eoerror_value_MC_motor_overheating                  = 18
+    eoerror_value_MC_motor_overheating                  = 18,
+    eoerror_value_MC_motor_tdb_not_reading              = 19
 } eOerror_value_MC_t;
 
-enum { eoerror_value_MC_numberof = 19 };
+enum { eoerror_value_MC_numberof = 20 };
 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -79,7 +79,7 @@ typedef union
         unsigned CAN_IsWarnTX           :1;
         unsigned CAN_IsWarnRX           :1;
         unsigned OverHeatingFailure     :1;
-        unsigned unused                 :1;
+        unsigned I2C_CommFailure        :1;
         //B2 L
         unsigned ADCCalFailure          :1; 
         unsigned I2TFailure             :1;                     


### PR DESCRIPTION
This PR brings the following change:

- Add new errors for specifying the diagnostic of the AMO encoder
- Prepare new error for the case in which the TDB is not reading (currently the error cannot be enable since it is never sent by the 2FOC fw but it will be done soon)
- Update version to v1.41.3