### PR TITLE
Best effort execution mode for RX, DO and TX phases of ETH boards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(icub_firmware_shared VERSION 1.43.0)
+project(icub_firmware_shared VERSION 1.43.1)
 
 find_package(YCM 0.11.0 REQUIRED)
 

--- a/embot/tools/embot_tools.h
+++ b/embot/tools/embot_tools.h
@@ -44,8 +44,8 @@ namespace embot { namespace tools {
             std::uint64_t min {0};        // the start value of first interval.
             std::uint64_t max {0};        // the upper limit of all possible values (which is actually max-1).
             std::uint32_t step {0};       // the width of the interval 
-            Config() = default;
-            Config(std::uint64_t mi, std::uint64_t ma, std::uint32_t st) : min(mi), max(ma), step(st) {}
+            constexpr Config() = default;
+            constexpr Config(std::uint64_t mi, std::uint64_t ma, std::uint32_t st) : min(mi), max(ma), step(st) {}
             std::uint64_t range() const { return max - min; }
             std::uint32_t nsteps() const { return ( (range() + step - 1) / step); }
             bool isvalid() const { return ((0 == step) || (min >= max)) ? false : true; }

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -167,6 +167,7 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_canservices_monitor_stillnocontact,  "SYS: a service has detected that some CAN boards are still not transmitting.", "In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits), in in par64 MS 32 bits the total disappearence time in ms"},
     {eoerror_value_SYS_canservices_monitor_retrievedcontact, "SYS: a service has recovered all CAN boards that were not transmitting.", "In sourceaddress the eOmn_serv_category_t"},
     {eoerror_value_SYS_exec_time_stats, "SYS: execution time statistics (min, average, max) us in a period", "(us min, us average, us max, ms period) is in par64, thread id in par16"},
+    {eoerror_value_SYS_ctrloop_execoverflowPERIOD, "SYS: execution time overflow (budget, actual, TX, DO, TX) us in a period", "us budget is in par16, (us actual, RX, DO, TX) is in par64"} 
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.c
+++ b/eth/embobj/plus/comm-v2/icub/EoError.c
@@ -167,7 +167,8 @@ const eoerror_valuestring_t eoerror_valuestrings_SYS[] =
     {eoerror_value_SYS_canservices_monitor_stillnocontact,  "SYS: a service has detected that some CAN boards are still not transmitting.", "In sourceaddress the eOmn_serv_category_t, in par64 LS 32 bits the bit mask of lost board (CAN1 in MS 16 bits and CAN2 in LS 16 bits), in in par64 MS 32 bits the total disappearence time in ms"},
     {eoerror_value_SYS_canservices_monitor_retrievedcontact, "SYS: a service has recovered all CAN boards that were not transmitting.", "In sourceaddress the eOmn_serv_category_t"},
     {eoerror_value_SYS_exec_time_stats, "SYS: execution time statistics (min, average, max) us in a period", "(us min, us average, us max, ms period) is in par64, thread id in par16"},
-    {eoerror_value_SYS_ctrloop_execoverflowPERIOD, "SYS: execution time overflow (budget, actual, TX, DO, TX) us in a period", "us budget is in par16, (us actual, RX, DO, TX) is in par64"} 
+    {eoerror_value_SYS_ctrloop_execoverflowPERIOD, "SYS: execution time overflow (budget, actual, TX, DO, TX) us in a period", "us budget is in par16, (us actual, RX, DO, TX) is in par64"}, 
+    {eoerror_value_SYS_ctrloop_histogramPERIOD, "SYS: execution time histogram", " par64 keeps in each U8 the percentage of its bin in steps of par16"} 
 };  EO_VERIFYsizeof(eoerror_valuestrings_SYS, eoerror_value_SYS_numberof*sizeof(const eoerror_valuestring_t)) 
 
 

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -178,11 +178,12 @@ typedef enum
     eoerror_value_SYS_canservices_monitor_lostcontact       = 61,
     eoerror_value_SYS_canservices_monitor_stillnocontact    = 62,
     eoerror_value_SYS_canservices_monitor_retrievedcontact  = 63,
-    eoerror_value_SYS_exec_time_stats                       = 64
+    eoerror_value_SYS_exec_time_stats                       = 64,
+    eoerror_value_SYS_ctrloop_execoverflowPERIOD            = 65
     
 } eOerror_value_SYS_t;
 
-enum { eoerror_value_SYS_numberof = 65 };
+enum { eoerror_value_SYS_numberof = 66 };
 
 
 /** @typedef    typedef enum eOerror_value_HW_t

--- a/eth/embobj/plus/comm-v2/icub/EoError.h
+++ b/eth/embobj/plus/comm-v2/icub/EoError.h
@@ -179,11 +179,12 @@ typedef enum
     eoerror_value_SYS_canservices_monitor_stillnocontact    = 62,
     eoerror_value_SYS_canservices_monitor_retrievedcontact  = 63,
     eoerror_value_SYS_exec_time_stats                       = 64,
-    eoerror_value_SYS_ctrloop_execoverflowPERIOD            = 65
+    eoerror_value_SYS_ctrloop_execoverflowPERIOD            = 65,
+    eoerror_value_SYS_ctrloop_histogramPERIOD               = 66
     
 } eOerror_value_SYS_t;
 
-enum { eoerror_value_SYS_numberof = 66 };
+enum { eoerror_value_SYS_numberof = 67 };
 
 
 /** @typedef    typedef enum eOerror_value_HW_t

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -55,8 +55,6 @@ extern "C" {
 // - public #define  --------------------------------------------------------------------------------------------------
 
 
-#define EOMANAGEMENT_useRUNNERMODE
-
 // it allows to fit a EOarray of 64 bytes (or 16 words)
 #define EOMANAGEMENT_COMMAND_DATA_SIZE 68
 //#warning: review it
@@ -294,7 +292,6 @@ typedef enum
     eomn_appl_runnermode_synchronized = 1
 } eOmn_appl_runnermode_t; 
 
-#if defined(EOMANAGEMENT_useRUNNERMODE)
 
 /** @typedef    typedef struct eOmn_appl_config_t;
     @brief      used to configure the application
@@ -311,24 +308,7 @@ typedef struct                      // size is 4+3*2+1+1+4 = 16 bytes
     eOmn_appl_config_logging_t      logging;  
 } eOmn_appl_config_t;               EO_VERIFYsizeof(eOmn_appl_config_t, 16)
 
-#else
 
-/** @typedef    typedef struct eOmn_appl_config_t;
-    @brief      used to configure the application
- **/
-typedef struct                      // size is 4+3+3 = 8 bytes
-{
-    eOreltime_t                     cycletime;      // in usec
-    uint16_t                        maxtimeRX;      // in usec
-    uint16_t                        maxtimeDO;      // in usec         
-    uint16_t                        maxtimeTX;      // in usec  
-    uint8_t                         txratedivider;  // if equal to 1 (or 0) the cycle sends up packets at every cycles, if 2 it sends up packets every two cycles
-    uint8_t                         filler01[1];
-    eOmn_appl_config_logging_t      logging;  
-} eOmn_appl_config_t;               EO_VERIFYsizeof(eOmn_appl_config_t, 16)
-
-
-#endif
 
 /** @typedef    typedef struct eOmn_appl_status_t;
     @brief      used to report status of the application

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -55,7 +55,7 @@ extern "C" {
 // - public #define  --------------------------------------------------------------------------------------------------
 
 
-
+//#define EOMANAGEMENT_useRUNNERMODE
 
 // it allows to fit a EOarray of 64 bytes (or 16 words)
 #define EOMANAGEMENT_COMMAND_DATA_SIZE 68
@@ -284,6 +284,32 @@ typedef struct
     uint16_t                        period10ms; // in 10*ms so that we manage ut to 10 minutes. used by periodic logs    
 } eOmn_appl_config_logging_t;
 
+
+typedef enum 
+{
+    eom_appl_runnermode_1slot = 0, 
+    eom_appl_runnermode_3slots = 1
+} eOmn_appl_runnermode_t; 
+
+#if defined(EOMANAGEMENT_useRUNNERMODE)
+
+/** @typedef    typedef struct eOmn_appl_config_t;
+    @brief      used to configure the application
+ **/
+typedef struct                      // size is 4+3*2+1+1+4 = 16 bytes
+{
+    uint16_t                        cycletime;      // in usec
+    uint16_t                        maxtimeRX;      // in usec
+    uint16_t                        maxtimeDO;      // in usec         
+    uint16_t                        maxtimeTX;      // in usec 
+    uint16_t                        safetygap;      // in usec    
+    uint8_t                         txratedivider;  // if equal to 1 (or 0) the cycle sends up packets at every cycles, if 2 it sends up packets every two cycles
+    uint8_t                         runnermode;     // use eOmn_appl_runnermode_t
+    eOmn_appl_config_logging_t      logging;  
+} eOmn_appl_config_t;               EO_VERIFYsizeof(eOmn_appl_config_t, 16)
+
+#else
+
 /** @typedef    typedef struct eOmn_appl_config_t;
     @brief      used to configure the application
  **/
@@ -298,6 +324,8 @@ typedef struct                      // size is 4+3+3 = 8 bytes
     eOmn_appl_config_logging_t      logging;  
 } eOmn_appl_config_t;               EO_VERIFYsizeof(eOmn_appl_config_t, 16)
 
+
+#endif
 
 /** @typedef    typedef struct eOmn_appl_status_t;
     @brief      used to report status of the application

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -291,7 +291,7 @@ typedef struct
 typedef enum 
 {
     eomn_appl_runnermode_besteffort = 0, 
-    eomn_appl_runnermode_syncronized = 1
+    eomn_appl_runnermode_synchronized = 1
 } eOmn_appl_runnermode_t; 
 
 #if defined(EOMANAGEMENT_useRUNNERMODE)

--- a/eth/embobj/plus/comm-v2/icub/EoManagement.h
+++ b/eth/embobj/plus/comm-v2/icub/EoManagement.h
@@ -55,7 +55,7 @@ extern "C" {
 // - public #define  --------------------------------------------------------------------------------------------------
 
 
-//#define EOMANAGEMENT_useRUNNERMODE
+#define EOMANAGEMENT_useRUNNERMODE
 
 // it allows to fit a EOarray of 64 bytes (or 16 words)
 #define EOMANAGEMENT_COMMAND_DATA_SIZE 68
@@ -274,8 +274,11 @@ typedef struct                      // size is 8+32+80+0 = 120 bytes
 
 typedef enum
 {
-    eomn_appl_log_asynchro_exectime_overflow    = 0,    // if used it sends logging as an overflow of execution time happens in the runner
-    eomn_appl_log_periodic_exectime_statistics  = 1     // if used it sends periodic logging on stats of the runner    
+    eomn_appl_log_asynchro_exectime_rxdotx_overflow     = 0,    // it sends logging as an overflow of execution time rx, do and tx in the runner
+    eomn_appl_log_periodic_exectime_rxdotx_minavgmax    = 1,    // it sends periodic logging on stats (min, avg, max) for rx, do and tx in the runner 
+    eomn_appl_log_asynchro_exectime_period_overflow     = 2,    // it sends logging as an overflow of execution time in the runner  
+    eomn_appl_log_periodic_exectime_period_minavgmax    = 3,    // it sends periodic logging on stats (min, avg, max) for execution time in the runner    
+    eomn_appl_log_periodic_exectime_period_histogram    = 4     // it sends periodic logging on stats (min, avg, max) for execution time in the runner
 } eOmn_appl_log_flags_t;
 
 typedef struct 
@@ -287,8 +290,8 @@ typedef struct
 
 typedef enum 
 {
-    eom_appl_runnermode_1slot = 0, 
-    eom_appl_runnermode_3slots = 1
+    eomn_appl_runnermode_besteffort = 0, 
+    eomn_appl_runnermode_syncronized = 1
 } eOmn_appl_runnermode_t; 
 
 #if defined(EOMANAGEMENT_useRUNNERMODE)

--- a/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
+++ b/eth/embobj/plus/comm-v2/protocol/api/EoProtocolMN.h
@@ -58,7 +58,7 @@ extern "C" {
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 
 
-enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 24 };
+enum { eoprot_version_mn_major = 2, eoprot_version_mn_minor = 25 };
 
 
 enum { eoprot_entities_mn_numberof = eomn_entities_numberof };


### PR DESCRIPTION
This PR adds support for the best effort mode for the execution of the RX, Do and TX phases for all ETH boards and for an improved reporting about their execution times.

In particular:
- improved `eOmn_appl_config_t` so that it contains extra parameters
- added new error codes for reporting overflows and statistics

Full details are in:
- https://github.com/robotology/icub-firmware/pull/617 for the new mode and for explanation of improved reporting,
- https://github.com/robotology/robots-configuration/pull/746 for how to use xml to configure the behavior of the ETH board


## Associated PRs
- https://github.com/robotology/icub-firmware/pull/617
- https://github.com/robotology/icub-firmware-shared/pull/115
- https://github.com/robotology/icub-main/pull/1030
- https://github.com/robotology/robots-configuration/pull/746
- https://github.com/robotology/icub-firmware-build/pull/215
