### PR TITLE
Fix eomc_controlmode2string and map_of_controlmodes

### DIFF
--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.c
@@ -195,7 +195,6 @@ static const eOmap_str_str_i08_t s_eomc_map_of_controlmodes[] =
     {"vel_direct", "eomc_ctrlmval_vel_direct", eomc_ctrlmval_vel_direct},
     {"openloop", "eomc_ctrlmval_openloop", eomc_ctrlmval_openloop},
     {"everything_off", "eomc_ctrlmval_everything_off", eomc_ctrlmval_everything_off},
-    {"calib", "eomc_ctrlmval_calib", eomc_ctrlmval_calib},
     
     {"unknown", "eomc_ctrlmval_unknownError", eomc_ctrlmval_unknownError}
 };
@@ -460,6 +459,12 @@ extern const char * eomc_controlmode2string(eOenum08_t controlmode, eObool_t use
     const uint8_t size = sizeof(s_eomc_map_of_controlmodes)/sizeof(eOmap_str_str_i08_t);
     const char * str = eo_common_map_str_str_i08__value2string(map, size, value, usecompactstring);
     
+    if(NULL == str)
+    {
+        str = (eobool_true == usecompactstring) ? (map[size-1].str0) : (map[size-1].str1);
+    }    
+    
+    return(str);       
 }
 
 extern eOenum08_t eomc_string2controlmode(const char * string, eObool_t usecompactstring)

--- a/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
+++ b/eth/embobj/plus/comm-v2/icub/EoMotionControl.h
@@ -1018,7 +1018,7 @@ typedef struct
     @brief      eOmc_motor_config_t contains the values required to configure a motor
     @warning    This struct must be of fixed size and multiple of 4.
  **/
-typedef struct                  // size is: 40+40+4+4+4+6+2+1+1+1+1+4+2+2+8+36 = 156
+typedef struct                  // size is: 40+40+40+4+4+4+6+2+1+1+1+1+4+4+2+2+8+36 = 200
 {
     eOmc_PID_t                      pidcurrent;                 /**< the pid for current control */
     eOmc_PID_t                      pidvelpwm;                   /**< the pid for speed control with pwm output */
@@ -1472,7 +1472,7 @@ typedef struct
 
 
 typedef struct
-{   // 4+ 80 + 64 + 64 + 96 = 308
+{   // 4 + 64 + 64 + 80 + 96 = 308
     uint8_t                         joint2set[4];       // it contains the set each joint belongs to. Use eOmc_jointSetNumber_t values
     eOmc_4x4_matrix_t               joint2motor;
     eOmc_4x4_matrix_t               motor2joint; 
@@ -1481,7 +1481,7 @@ typedef struct
 } eOmc_4jomo_coupling_t; EO_VERIFYsizeof(eOmc_4jomo_coupling_t, 308)
 
 typedef struct
-{   // 4 + + 64 + 64 + 64 + 80 = 260
+{   // 4 + 64 + 64 + 64 + 80 = 276
     uint8_t                         joint2set[4];       // it contains the set each joint belongs to. Use eOmc_jointSetNumber_t values
     eOmc_4x4_matrix_t               joint2motor;
     eOmc_4x4_matrix_t               motor2joint; 


### PR DESCRIPTION
Minor: update some comments regarding the protocol structure size

Tested on torsojoint setup